### PR TITLE
Raise appropriate exception when failing to match instruction node

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -224,7 +224,10 @@ module REXML
             standalone = standalone[1] unless standalone.nil?
             return [ :xmldecl, version, encoding, standalone ]
           when INSTRUCTION_START
-            return [ :processing_instruction, *@source.match(INSTRUCTION_PATTERN, true)[1,2] ]
+            if (pi = @source.match(INSTRUCTION_PATTERN, true)).nil?
+              raise REXML::ParseException.new("Incomplete processing instruction node")
+            end
+            return [ :processing_instruction, *pi[1,2] ]
           when DOCTYPE_START
             md = @source.match( DOCTYPE_PATTERN, true )
             @nsstack.unshift(curr_ns=Set.new)


### PR DESCRIPTION
## Short introduction
Hi, I've been fuzzing rexml (with [kisaten](https://github.com/zelivans/kisaten)) and found multiple bugs, I will attempt to fix what I can and send PRs, or open issues for the rest. This bug is the first.

## The bug
When rexml finds an incomplete processing instruction node, it fails with a `NoMethodError` that is caught by a `REXML::ParseException`, due to the `match` function returning nil. This proposed fix raises an informative exception message when the match fails.

```
/home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/parsers/treeparser.rb:96:in `rescue in parse': #<NoMethodError: undefined method `[]' for nil:NilClass> (REXML::ParseException)
```

## Example input
Try parsing with `REXML::Document.new` any of the following: `<?>`, `<? bla >`