### PR TITLE
Raise appropriate exception when failing to match end tag

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -339,8 +339,8 @@ module REXML
               #md = @source.match_to_consume( '>', CLOSE_MATCH)
               md = @source.match( CLOSE_MATCH, true )
               raise REXML::ParseException.new( "Missing end tag for "+
-                "'#{last_tag}' (got \"#{md[1]}\")",
-                @source) unless last_tag == md[1]
+                "'#{last_tag}'" + (md.nil? ? "" : " (got \"#{md[1]}\")"),
+                @source) if md.nil? or last_tag != md[1]
               return [ :end_element, last_tag ]
             elsif @source.buffer[1] == ?!
               md = @source.match(/\A(\s*[^>]*>)/um)


### PR DESCRIPTION
In `BaseParser#pull_event`, when the ending tag can't be matched, `md` resolves to nil. The subsequent check of the value of `md[1]` will fail with `NoMethodError` (caught with `REXML::ParseException`). This proposed fix prevents the nil call and raises a `REXML::ParseException` directly.

```
/home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/parsers/baseparser.rb:442:in `rescue in pull_event': #<NoMethodError: undefined method `[]' for nil:NilClass> (REXML::ParseException)
```

## Example input
With `REXML::Document.new` try:
```
<b></
```