### PR TITLE
Prevent TypeError and ArgumentError crash (nil to string conversion) in default formatter

### DIFF
--- a/lib/rexml/formatters/default.rb
+++ b/lib/rexml/formatters/default.rb
@@ -102,9 +102,9 @@ module REXML
 
       def write_instruction( node, output )
         output << Instruction::START.sub(/\\/u, '')
-        output << node.target
+        output << (node.target || '')
         output << ' '
-        output << node.content
+        output << (node.content || '')
         output << Instruction::STOP.sub(/\\/u, '')
       end
     end

--- a/lib/rexml/formatters/default.rb
+++ b/lib/rexml/formatters/default.rb
@@ -66,7 +66,7 @@ module REXML
 
         node.attributes.to_a.map { |a|
           Hash === a ? a.values : a
-        }.flatten.sort_by {|attr| attr.name}.each do |attr|
+        }.flatten.sort_by {|attr| attr.name || '' }.each do |attr|
           output << " "
           attr.write( output )
         end unless node.attributes.empty?


### PR DESCRIPTION
In `REXML::Formatters::Default#write_instruction` a `TypeError` exception is raised when `node.content` is nil. I am not sure if it is ever supposed to become nil, but my fuzzer did catch cases where a `TypeError` was raised in these lines. I am proposing this naive fix, close if you prefer to write a better fix that prevents this issue or raises an appropriate exception.

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:107:in `write_instruction': no implicit conversion of nil into String (TypeError)
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:39:in `write'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:80:in `block in write_element'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:79:in `each'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:79:in `write_element'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:32:in `write'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:80:in `block in write_element'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:79:in `each'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:79:in `write_element'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/formatters/default.rb:32:in `write'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/node.rb:34:in `to_s'
	from tst.rb:6:in `puts'
	from tst.rb:6:in `puts'
	from tst.rb:6:in `block in <main>'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/element.rb:927:in `block in each'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/xpath.rb:68:in `each'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/xpath.rb:68:in `each'
	from /home/ariel/afl-kisaten/private/sandbox/rexml/rexml/lib/rexml/element.rb:927:in `each'
	from tst.rb:5:in `<main>'
```

I've uploaded one of the crashing files to [this gist](https://gist.github.com/zelivans/a9f7921e32e4489b8b032ead20f3a5f5). It can probably be further minimized if you want to write a test for this.