### PR TITLE
Rescue StandardError rather than Exception

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -398,7 +398,7 @@ module REXML
           raise
         rescue REXML::ParseException
           raise
-        rescue Exception, NameError => error
+        rescue => error
           raise REXML::ParseException.new( "Exception parsing",
             @source, self, (error ? error : $!) )
         end


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/pull/1994

`Exception` is rescuing many things it shouldn't rescue like `SignalException` for instance.