### PR TITLE
use #inspect to pretty-print meta-characters in error messages

### DIFF
--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -137,7 +137,7 @@ module REXML
             case c.ord
             when *VALID_CHAR
             else
-              raise "Illegal character #{c.inspect} in raw string \"#{string}\""
+              raise "Illegal character #{c.inspect} in raw string #{string.inspect}"
             end
           end
         else
@@ -145,7 +145,7 @@ module REXML
             case c.unpack('U')
             when *VALID_CHAR
             else
-              raise "Illegal character #{c.inspect} in raw string \"#{string}\""
+              raise "Illegal character #{c.inspect} in raw string #{string.inspect}"
             end
           end
         end
@@ -154,13 +154,13 @@ module REXML
       # context sensitive
       string.scan(pattern) do
         if $1[-1] != ?;
-          raise "Illegal character '#{$1}' in raw string \"#{string}\""
+          raise "Illegal character #{$1.inspect} in raw string #{string.inspect}"
         elsif $1[0] == ?&
           if $5 and $5[0] == ?#
             case ($5[1] == ?x ? $5[2..-1].to_i(16) : $5[1..-1].to_i)
             when *VALID_CHAR
             else
-              raise "Illegal character '#{$1}' in raw string \"#{string}\""
+              raise "Illegal character #{$1.inspect} in raw string #{string.inspect}"
             end
           # FIXME: below can't work but this needs API change.
           # elsif @parent and $3 and !SUBSTITUTES.include?($1)


### PR DESCRIPTION
When input texts include non-printable characters, e.g. "\b" (`^H`),  REXML gives up parsing it, printing the non-printable characters as is. This will confuse users because the error messages in a terminal may be broken.

This PR fixes the problem by using `#inspect` to pretty-print those non-printable characters.