### PR TITLE
Fix crash with nil XPath variables

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -165,8 +165,6 @@ module REXML
               object.to_s
             end
           end
-        when nil
-          ""
         else
           object.to_s
         end

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -135,8 +135,7 @@ module REXML
     #
     # An object of a type other than the four basic types is converted to a
     # string in a way that is dependent on that type.
-    def Functions::string( object=nil )
-      object = @@context[:node] if object.nil? && !@@context.nil?
+    def Functions::string( object=@@context[:node] )
       if object.respond_to?(:node_type)
         case object.node_type
         when :attribute

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -136,7 +136,7 @@ module REXML
     # An object of a type other than the four basic types is converted to a
     # string in a way that is dependent on that type.
     def Functions::string( object=nil )
-      object = @@context[:node] if object.nil?
+      object = @@context[:node] if object.nil? && !@@context.nil?
       if object.respond_to?(:node_type)
         case object.node_type
         when :attribute

--- a/test/rexml/test_functions.rb
+++ b/test/rexml/test_functions.rb
@@ -6,6 +6,12 @@ require "rexml/document"
 module REXMLTests
   class FunctionsTester < Test::Unit::TestCase
     include REXML
+
+    def setup
+      super
+      REXML::Functions.context = nil
+    end
+
     def test_functions
       # trivial text() test
       # confuse-a-function
@@ -223,9 +229,6 @@ module REXMLTests
     end
 
     def test_string_nil_without_context
-      # Reset to default value
-      REXML::Functions.class_variable_set(:@@context, nil)
-
       doc = REXML::Document.new(<<-XML)
       <?xml version="1.0" encoding="UTF-8"?>
       <root>

--- a/test/rexml/test_functions.rb
+++ b/test/rexml/test_functions.rb
@@ -222,6 +222,22 @@ module REXMLTests
       assert_equal( [REXML::Comment.new("COMMENT A")], m )
     end
 
+    def test_string_nil_without_context
+      # Reset to default value
+      REXML::Functions.class_variable_set(:@@context, nil)
+
+      doc = REXML::Document.new(<<-XML)
+      <?xml version="1.0" encoding="UTF-8"?>
+      <root>
+      <foo bar="baz"/>
+      <foo bar=""/>
+      </root>
+      XML
+
+      m = REXML::XPath.match(doc, "//foo[@bar=$n]", nil, { "n" => nil })
+      assert_equal( 1, m.size )
+    end
+
     def test_unregistered_method
       doc = Document.new("<root/>")
       assert_nil(XPath::first(doc.root, "to_s()"))


### PR DESCRIPTION
Prior to d91e124ab9843d2eaf62071bf029301254c36e2b, an XPath variable could be set to `nil`, in which case it would be silently converted to an empty string. This is clearly still the intended behaviour of this method, as can be seen from the (redundant) `when nil` further down. But, with the introduction of context support, this case was broken, because trying to do `@@context[:node]` would raise a `NoMethodError` if there was no context.

I also noticed that then `when nil` case was redundant, since without it it'll use `nil.to_s`, which is already the empty string, so I removed that in a seperate commit.