### PR TITLE
Message less confusing error to human

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -336,8 +336,7 @@ module REXML
               last_tag = @tags.pop
               md = @source.match( CLOSE_MATCH, true )
               if md and !last_tag
-                message = "Unexpected top-level end tag"
-                message << " (got '#{md[1]}')" if md
+                message = "Unexpected top-level end tag (got '#{md[1]}')"
                 raise REXML::ParseException.new(message, @source)
               end
               if md.nil? or last_tag != md[1]

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -335,6 +335,11 @@ module REXML
               @nsstack.shift
               last_tag = @tags.pop
               md = @source.match( CLOSE_MATCH, true )
+              if md and !last_tag
+                message = "Unexpected top-level end tag"
+                message << " (got '#{md[1]}')" if md
+                raise REXML::ParseException.new(message, @source)
+              end
               if md.nil? or last_tag != md[1]
                 message = "Missing end tag for '#{last_tag}'"
                 message << " (got '#{md[1]}')" if md

--- a/test/rexml/parse/test_element.rb
+++ b/test/rexml/parse/test_element.rb
@@ -8,6 +8,19 @@ module REXMLTests
     end
 
     class TestInvalid < self
+      def test_top_level_end_tag
+        exception = assert_raise(REXML::ParseException) do
+          parse("</a>")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Unexpected top-level end tag (got 'a')
+Line: 1
+Position: 4
+Last 80 unconsumed characters:
+
+        DETAIL
+      end
+
       def test_no_end_tag
         exception = assert_raise(REXML::ParseException) do
           parse("<a></")


### PR DESCRIPTION
Message less confusing error to human

* Problem: Following error message is not helpful, because you have to reason
  that '' actually means it's in the top-level, and the 'div' (not '</div>') is
  an end tag

        require "rexml/parsers/lightparser"
        REXML::Parsers::LightParser.new('</div>').parse
        #=> Missing end tag for '' (got 'div')

* Solution: add a special case in error handling just to change the error message

        require "rexml/parsers/lightparser"
        REXML::Parsers::LightParser.new('</div>').parse
        #=> Unexpected top-level end tag (got 'div')
