### PR TITLE
Feature/XMLDecl#clone to copy @writethis attribute

### DIFF
--- a/lib/rexml/xmldecl.rb
+++ b/lib/rexml/xmldecl.rb
@@ -26,6 +26,7 @@ module REXML
         self.encoding = version.encoding
         @writeencoding = version.writeencoding
         @standalone = version.standalone
+        @writethis = version.writethis
       else
         super()
         @version = version

--- a/test/rexml/test_xml_declaration.rb
+++ b/test/rexml/test_xml_declaration.rb
@@ -38,5 +38,11 @@ module REXMLTests
                    "encoding=\"UTF-8\" standalone=\"yes\"?>",
                    @xml_declaration.to_s)
     end
+
+    def test_is_writethis_attribute_copied_by_clone
+      assert_equal(true, @xml_declaration.clone.writethis)
+      @xml_declaration.nowrite
+      assert_equal(false, @xml_declaration.clone.writethis)
+    end
   end
 end


### PR DESCRIPTION
`XMLDecl#clone` does not copy its `@writethis` attribute.

This causes that a deeply cloned XML document always outputs XML declaration
that is assumed by the library when the original XML doesn't have it.

```ruby
doc = REXML::Document.new "<root/>"
puts doc.to_s            # => "<root/>"
puts doc.deep_clone.to_s # => "<?xml version='1.0'?><root/>"
```

This fixes the behavior.

```ruby
doc = REXML::Document.new "<root/>"
puts doc.to_s            # => "<root/>"
puts doc.deep_clone.to_s # => "<root/>"
```