### PR TITLE
Add GitHub Actions script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    strategy:
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7, jruby]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          # eregon/use-ruby-action doesn't support JRuby on Windows
+          - ruby: jruby
+            platform: windows-latest
+      # TODO: Remove this after fixing all tests
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: eregon/use-ruby-action@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Build and Test
+        shell: bash
+        run: |
+          gem install bundler
+          bundle install --jobs=4 --retry=3
+          bundle exec rake


### PR DESCRIPTION
Unlike current Travis setup, this tests much more operating systems.

You may see that [it currently doesn't pass on JRuby](https://github.com/slonopotamus/rexml/commit/4cf0be5e7c3fab00392f15bf26e360ac9550f1a7/checks?check_suite_id=402610859). Unfortunately, fixing that is beyond my current Ruby skills. I see two options here - either someone helps with fixing tests on JRuby or I exclude JRuby from current PR and file a separate issue for fixing it.

Note: Ruby 2.3 is omitted, but given that it [reached EOL](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/) almost a year ago, it doesn't look like a big loss.
