### PR TITLE
Add actions, two test fixes for newer Rubies

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,34 @@
+name: rexml
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: >-
+      ${{ matrix.os }}  Ruby: ${{ matrix.ruby }}
+    env:
+      CI: true
+      TESTOPTS: -v
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, macos, windows-latest ]
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7 ]
+        exclude:
+          - os: windows-latest
+            ruby: 2.3
+
+    steps:
+    - name: repo checkout
+      uses: actions/checkout@v2
+
+    - name: load ruby
+      uses: eregon/use-ruby-action@master
+      with:
+        ruby-version: ${{ matrix.ruby }}
+
+    - name: test
+      run:  ruby run-test.rb
+      timeout-minutes: 5

--- a/test/lib/envutil.rb
+++ b/test/lib/envutil.rb
@@ -291,7 +291,7 @@ if defined?(RbConfig)
     end
     dir = File.dirname(ruby)
     CONFIG['bindir'] = dir
-    Gem::ConfigMap[:bindir] = dir if defined?(Gem::ConfigMap)
+    Gem::ConfigMap[:bindir] = dir if Gem::VERSION < '3.1' and defined?(Gem::ConfigMap)
   end
 end
 

--- a/test/lib/leakchecker.rb
+++ b/test/lib/leakchecker.rb
@@ -23,6 +23,7 @@ class LeakChecker
   end
 
   def check_safe test_name
+    return nil if RUBY_VERSION >= "2.7" # stop warnings
     puts "#{test_name}: $SAFE == #{$SAFE}" unless $SAFE == 0
   end
 


### PR DESCRIPTION
Actions - Ubuntu, macOS, Windows, Ruby 2.3 thru 2.7, except 2.3 on Windows

rexml is freezing in ruby/ruby macOS CI.  Wanted to check here on 2.7, etc.

Minimal changes to two test/lib files, just enough to stop extraneous output.