### PR TITLE
`require "rexml/document"` by default

### DIFF
--- a/lib/rexml.rb
+++ b/lib/rexml.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "rexml/document"

--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
     "NEWS.md",
     "README.md",
     "Rakefile",
+    "lib/rexml.rb",
     "lib/rexml/attlistdecl.rb",
     "lib/rexml/attribute.rb",
     "lib/rexml/cdata.rb",


### PR DESCRIPTION
It would be convenient if users can use `REXML::Document` without explicitly `require "rexml/document"`.
https://guides.rubygems.org/name-your-gem/

I heard the following Gemfile setting in a real world application development:

```ruby
# Gemfile
gem "rexml", require: "rexml/document"
```

So, I think this could be unnecessary if "rexml/document" will be required by default as a endpoint.