### PR TITLE
Refine dclone definitions not to leak outside of REXML

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -7,38 +7,44 @@ require_relative 'xmltokens'
 require_relative 'attribute'
 require_relative 'parsers/xpathparser'
 
-class Object
-  # provides a unified +clone+ operation, for REXML::XPathParser
-  # to use across multiple Object types
-  def dclone
-    clone
+module REXML
+  module DClonable
+    refine Object do
+      # provides a unified +clone+ operation, for REXML::XPathParser
+      # to use across multiple Object types
+      def dclone
+        clone
+      end
+    end
+    refine Symbol do
+      # provides a unified +clone+ operation, for REXML::XPathParser
+      # to use across multiple Object types
+      def dclone ; self ; end
+    end
+    refine Integer do
+      # provides a unified +clone+ operation, for REXML::XPathParser
+      # to use across multiple Object types
+      def dclone ; self ; end
+    end
+    refine Float do
+      # provides a unified +clone+ operation, for REXML::XPathParser
+      # to use across multiple Object types
+      def dclone ; self ; end
+    end
+    refine Array do
+      # provides a unified +clone+ operation, for REXML::XPathParser
+      # to use across multiple Object+ types
+      def dclone
+        klone = self.clone
+        klone.clear
+        self.each{|v| klone << v.dclone}
+        klone
+      end
+    end
   end
 end
-class Symbol
-  # provides a unified +clone+ operation, for REXML::XPathParser
-  # to use across multiple Object types
-  def dclone ; self ; end
-end
-class Integer
-  # provides a unified +clone+ operation, for REXML::XPathParser
-  # to use across multiple Object types
-  def dclone ; self ; end
-end
-class Float
-  # provides a unified +clone+ operation, for REXML::XPathParser
-  # to use across multiple Object types
-  def dclone ; self ; end
-end
-class Array
-  # provides a unified +clone+ operation, for REXML::XPathParser
-  # to use across multiple Object+ types
-  def dclone
-    klone = self.clone
-    klone.clear
-    self.each{|v| klone << v.dclone}
-    klone
-  end
-end
+
+using REXML::DClonable
 
 module REXML
   # You don't want to use this class.  Really.  Use XPath, which is a wrapper


### PR DESCRIPTION
While investigating my app, I found an unfamiliar `dclone` method on `Object`, which turned out to be defined here in `xpath_parser.rb` only for using in `xpath_parser.rb`.

I believe this is the very use case of Ruby's most underevaluated feature, Refinements.

With this patch, we're no longer seeing the `dclone` method leaking into our apps.