### PR TITLE
Enhanced RDoc for Document

### DIFF
--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -112,9 +112,6 @@ module REXML
       Document.new self
     end
 
-    # :call-seq:
-    #   expanded_name -> empty_string
-    #
     # Returns an empty string.
     #
     def expanded_name

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -112,6 +112,9 @@ module REXML
       Document.new self
     end
 
+    # :call-seq:
+    #   expanded_name -> empty_string
+    #
     # Returns an empty string.
     #
     def expanded_name


### PR DESCRIPTION
Revises prefatory material, and methods:
- new
- node_type
- clone
- expanded_name
- add

Note well:  When I run this through rdoc, the call-seq for method expanded_name, and its aliased method name, does not show up.  I have no theory that explains that.