### PR TITLE
Code fix, test, and RDoc for Parent#index

### DIFF
--- a/lib/rexml/parent.rb
+++ b/lib/rexml/parent.rb
@@ -116,14 +116,23 @@ module REXML
       @children.dup
     end
 
-    # Fetches the index of a given child
-    # @param child the child to get the index of
-    # @return the index of the child, or nil if the object is not a child
-    # of this parent.
-    def index( child )
+    # :call-seq:
+    #   index(child) -> integer or nil
+    #
+    # Returns the index of the given +child+ if it exists,
+    # +nil+ otherwise:
+    #
+    #   d = REXML::Document.new('<root><a/><b/><c/><d/></root>')
+    #   root = d.root               # => <root> ... </>
+    #   a, b, c, d = *root.children # => [<a/>, <b/>, <c/>, <d/>]
+    #   root.index(a)               # => 0
+    #   root.delete(a)              # => <a/>
+    #   root.index(a)               # => nil
+    #
+    def index(child)
       count = -1
-      @children.find { |i| count += 1 ; i.hash == child.hash }
-      count
+      @children.find { |i| count += 1 ; return count if i.hash == child.hash }
+      return nil
     end
 
     # @return the number of children of this parent

--- a/test/test_parent.rb
+++ b/test/test_parent.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: false
+
+module REXMLTests
+  class ParentTester < Test::Unit::TestCase
+    # Returns a parent that has children.
+    # This is because it's not safe to test with Document,
+    # which may have (and sometimes actually has) overridden Parent's methods.
+    def parent_with_children
+      p = REXML::Parent.new
+      p.add(REXML::Element.new('a'))
+      p.add(REXML::Text.new('text'))
+      p.add(REXML::Element.new('b'))
+      p.add(REXML::Element.new('c'))
+      p
+    end
+
+    def test_index
+      # No children.
+      p = REXML::Parent.new
+      e = REXML::Element.new('foo')
+      assert_equal(nil, p.index(e))
+      # Children.
+      p = parent_with_children
+      a, _, _, c = *p.children
+      # First child.
+      assert_equal(0, p.index(a))
+      # Last child.
+      assert_equal(3, p.index(c))
+      # Not a child.
+      assert_equal(nil, p.index(e))
+    end
+
+  end
+end


### PR DESCRIPTION
The method failed to return nil both for an empty parent, and for parent not containing the child.

I've created file test/test_parent.rb because there will be more tests for this class, and I think there are a couple more bugs (think insert_before and insert_after).