### PR TITLE
Use ruby/setup-ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
       - name: Install dependencies
         run: |
           bundle install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
       - name: Install dependencies
         run: |
           bundle install


### PR DESCRIPTION
`actions/setup-ruby` is deprecated now. I replaced it to `ruby/setup-ruby`.