### PR TITLE
Add 2.5 as minimum required ruby version for gem

### DIFF
--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -55,6 +55,8 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
+  spec.required_ruby_version = '>= 2.5.0'
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"


### PR DESCRIPTION
This gem is no longer tested with Rubies older than 2.5, and it's actually broken on at least <= 2.2.

By setting the minimum version in the `gemspec`, we ensure that older Ruby versions don't try to use an incompatible `rexml` version.

_Outdated original description:_

> ~~Ruby 2.3 is the oldest Ruby that still passes all tests when running `rake test`. By setting it in the ~`gemfile`~ gemspec (edit), we ensure that older Ruby versions don't try to use an incompatible `rexml` version.~~
>~~(Note: It's probably trivial to support the older Rubies, but I'll leave that for someone who is interested enough in doing the extra work)~~
> ~~I've taken the liberty of also updating the `NEWS.md`, so that this is ready to release. See #69 for details :)~~