### PR TITLE
Fix typo in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
   * `require "rexml/document"` by default.
     [GitHub#36][Patch by Koichi ITO]
 
-  * Don't add `#dcloe` method to core classes globally.
+  * Don't add `#dclone` method to core classes globally.
     [GitHub#37][Patch by Akira Matsuda]
 
   * Add more documentations.


### PR DESCRIPTION
#37 fixes leakage of `#dclone` method (not `#dcloe`)