### PR TITLE
Access constants with :: instead of . in DTD::Parser.

### DIFF
--- a/lib/rexml/dtd/dtd.rb
+++ b/lib/rexml/dtd/dtd.rb
@@ -23,19 +23,19 @@ module REXML
         contents = Parent.new
         while input.size > 0
           case input
-          when ElementDecl.PATTERN_RE
+          when ElementDecl::PATTERN_RE
             match = $&
             contents << ElementDecl.new( match )
-          when AttlistDecl.PATTERN_RE
+          when AttlistDecl::PATTERN_RE
             matchdata = $~
             contents << AttlistDecl.new( matchdata )
-          when EntityDecl.PATTERN_RE
+          when EntityDecl::PATTERN_RE
             matchdata = $~
             contents << EntityDecl.new( matchdata )
-          when Comment.PATTERN_RE
+          when Comment::PATTERN_RE
             matchdata = $~
             contents << Comment.new( matchdata )
-          when NotationDecl.PATTERN_RE
+          when NotationDecl::PATTERN_RE
             matchdata = $~
             contents << NotationDecl.new( matchdata )
           end


### PR DESCRIPTION
I was trying to use REXML's DTD parser today. Here's what I did:

```ruby
require 'rexml/dtd/dtd'
dtd = REXML::DTD::Parser.parse(File.read('/path/to/file.dtd'))
```

The code above produced the following error:

/Users/camertron/.asdf/installs/ruby/3.0.2/lib/ruby/gems/3.0.0/gems/rexml-3.2.5/lib/rexml/dtd/dtd.rb:26:in \`parse_helper': undefined method \`PATTERN_RE' for REXML::DTD::ElementDecl:Class (NoMethodError)

I took a peek at the code and discovered that `PATTERN_RE` is indeed not a method but instead a constant, and should be looked up using the `::` syntax instead of `.`.

It seems a little strange that nobody's noticed this before, so... am I missing something?