### PR TITLE
CI against Ruby 3.0, 3.1, and 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
           - jruby
         # include:
         #   - runs-on: ubuntu-latest


### PR DESCRIPTION
Here's a patch that adds CI configurations for Rubies 3.0, 3.1, and 3.2 that are currently untested.