### PR TITLE
xpath abbreviate: add support for string literal that contains double-quote

### DIFF
--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -188,6 +188,7 @@ module REXML
         return string.squeeze(" ")
       end
 
+      private
       def quote_literal( literal )
         case literal
         when String
@@ -203,7 +204,6 @@ module REXML
         end
       end
 
-      private
       #LocationPath
       #  | RelativeLocationPath
       #  | '/' RelativeLocationPath?

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -178,7 +178,7 @@ module REXML
         when :literal
           path.shift
           string << " "
-          string << path.shift.inspect
+          string << QuoteLiteral(path.shift)
           string << " "
         else
           string << " "
@@ -361,6 +361,18 @@ module REXML
           OrExpr(pred, preds)
         }
         path
+      end
+
+      def QuoteLiteral literal
+        case literal
+        when String
+          # Xpath 1.0 does not support escape characters.
+          # Assumes literal does not contain both single and double quotes.
+          pattern = literal.include?('"') ? "'%s'" : '"%s"'
+          pattern % literal
+        else
+          literal.inspect
+        end
       end
 
       # The following return arrays of true/false, a 1-1 mapping of the

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -178,7 +178,7 @@ module REXML
         when :literal
           path.shift
           string << " "
-          string << QuoteLiteral(path.shift)
+          string << quote_literal(path.shift)
           string << " "
         else
           string << " "
@@ -186,6 +186,21 @@ module REXML
           string << " "
         end
         return string.squeeze(" ")
+      end
+
+      def quote_literal( literal )
+        case literal
+        when String
+          # XPath 1.0 does not support escape characters.
+          # Assumes literal does not contain both single and double quotes.
+          if literal.include?("'")
+            "\"#{literal}\""
+          else
+            "'#{literal}'"
+          end
+        else
+          literal.inspect
+        end
       end
 
       private
@@ -361,18 +376,6 @@ module REXML
           OrExpr(pred, preds)
         }
         path
-      end
-
-      def QuoteLiteral literal
-        case literal
-        when String
-          # Xpath 1.0 does not support escape characters.
-          # Assumes literal does not contain both single and double quotes.
-          pattern = literal.include?('"') ? "'%s'" : '"%s"'
-          pattern % literal
-        else
-          literal.inspect
-        end
       end
 
       # The following return arrays of true/false, a 1-1 mapping of the


### PR DESCRIPTION
This adds support for a string literal that contains a double-quote to `XPathParser#abbreviate`. Basically any literal that contains a double-quote `"` must be quoted by single-quotes `'` since XPath 1.0 does not support any escape characters.

The change improves the following test script
```ruby
require 'rexml'

parsed = REXML::Parsers::XPathParser.new.parse('/a[b/text()=concat("c\'",\'"d\')]')
puts "#{parsed}"
puts ""
appreviated = REXML::Parsers::XPathParser.new.abbreviate parsed
puts "#{appreviated}"
```
### Output Before Change
```
[:document, :child, :qname, "", "a", :predicate, [:eq, [:child, :qname, "", "b", :child, :text], [:function, "concat", [[:literal, "c'"], [:literal, "\"d"]]]]]

/a[ b/text() = concat( "c'" , "\"d" ) ]
```
### Output After Change
```
[:document, :child, :qname, "", "a", :predicate, [:eq, [:child, :qname, "", "b", :child, :text], [:function, "concat", [[:literal, "c'"], [:literal, "\"d"]]]]]

/a[ b/text() = concat( "c'" , '"d' ) ]
```