### PR TITLE
Fix XPathParser#abbreviate for . and .. when it is not the first node.

### DIFF
--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -52,11 +52,11 @@ module REXML
           when :child
             string << "/" if string.size > 0
           when :descendant_or_self
-            string << "//"
-          when :self
             string << "/"
+          when :self
+            string << "."
           when :parent
-            string << "/.."
+            string << ".."
           when :any
             string << "*"
           when :text

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -54,8 +54,10 @@ module REXML
           when :descendant_or_self
             string << "/"
           when :self
+            string << "/" if string.size > 0
             string << "."
           when :parent
+            string << "/" if string.size > 0
             string << ".."
           when :any
             string << "*"


### PR DESCRIPTION
Test code:
```ruby
require 'rexml'

def test_abbreviate xpath
  parser = REXML::Parsers::XPathParser.new
  test = parser.abbreviate parser.parse(xpath)
  puts "expected(#{xpath}) actual(#{test})"
end

test_abbreviate('/a/b/.')
test_abbreviate('./a')
test_abbreviate('/a/b/..')
test_abbreviate('../a')
```

### Output Before PR
```
expected(/a/b/.) actual(/a/b/)
expected(./a) actual(//a)
expected(/a/b/..) actual(/a/b/..)
expected(../a) actual(/../a)
```

### Output With This PR
```
expected(/a/b/.) actual(/a/b/.)
expected(./a) actual(./a)
expected(/a/b/..) actual(/a/b/..)
expected(../a) actual(../a)
```