### PR TITLE
Use string scanner with baseparser

### DIFF
--- a/benchmark/parse.yaml
+++ b/benchmark/parse.yaml
@@ -5,6 +5,8 @@ contexts:
     require: false
     prelude: require 'rexml'
   - name: master
+    gems:
+      strscan: 3.0.8
     prelude: |
       $LOAD_PATH.unshift(File.expand_path("lib"))
       require 'rexml'
@@ -16,6 +18,8 @@ contexts:
       require 'rexml'
       RubyVM::YJIT.enable
   - name: master(YJIT)
+    gems:
+      strscan: 3.0.8
     prelude: |
       $LOAD_PATH.unshift(File.expand_path("lib"))
       require 'rexml'

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -274,8 +274,7 @@ module REXML
             return [ :elementdecl, @source.match( ELEMENTDECL_PATTERN, true )[1] ]
 
           when ENTITY_START
-            match = @source.match( ENTITYDECL, true ).compact
-            match[0] = :entitydecl
+            match = [:entitydecl, *@source.match( ENTITYDECL, true ).captures.compact]
             ref = false
             if match[1] == '%'
               ref = true

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -392,6 +392,7 @@ module REXML
               unless md
                 raise REXML::ParseException.new("malformed XML: missing tag start", @source)
               end
+              tag = md[1]
               @document_status = :in_element
               prefixes = Set.new
               prefixes << md[2] if md[2]
@@ -405,23 +406,20 @@ module REXML
               end
 
               if closed
-                @closed = md[1]
+                @closed = tag
                 @nsstack.shift
               else
-                @tags.push( md[1] )
+                @tags.push( tag )
               end
-              return [ :start_element, md[1], attributes ]
+              return [ :start_element, tag, attributes ]
             end
           else
             md = @source.match( TEXT_PATTERN, true )
+            text = md[1]
             if md[0].length == 0
               @source.match( /(\s+)/, true )
             end
-            #STDERR.puts "GOT #{md[1].inspect}" unless md[0].length == 0
-            #return [ :text, "" ] if md[0].length == 0
-            # unnormalized = Text::unnormalize( md[1], self )
-            # return PullEvent.new( :text, md[1], unnormalized )
-            return [ :text, md[1] ]
+            return [ :text, text ]
           end
         rescue REXML::UndefinedNamespaceException
           raise

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -96,7 +96,7 @@ module REXML
       ENTITYDEF = "(?:#{ENTITYVALUE}|(?:#{EXTERNALID}(#{NDATADECL})?))"
       PEDECL = "<!ENTITY\\s+(%)\\s+#{NAME}\\s+#{PEDEF}\\s*>"
       GEDECL = "<!ENTITY\\s+#{NAME}\\s+#{ENTITYDEF}\\s*>"
-      ENTITYDECL = /\s*(?:#{GEDECL})|(?:#{PEDECL})/um
+      ENTITYDECL = /\s*(?:#{GEDECL})|\s*(?:#{PEDECL})/um
 
       NOTATIONDECL_START = /\A\s*<!NOTATION/um
       EXTERNAL_ID_PUBLIC = /\A\s*PUBLIC\s+#{PUBIDLITERAL}\s+#{SYSTEMLITERAL}\s*/um
@@ -274,7 +274,7 @@ module REXML
             return [ :elementdecl, @source.match( ELEMENTDECL_PATTERN, true )[1] ]
 
           when ENTITY_START
-            match = @source.match( ENTITYDECL, true ).to_a.compact
+            match = @source.match( ENTITYDECL, true ).compact
             match[0] = :entitydecl
             ref = false
             if match[1] == '%'

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -259,7 +259,7 @@ module REXML
           else
             @document_status = :after_doctype
             if @source.encoding == "UTF-8"
-              @source.buffer.force_encoding(::Encoding::UTF_8)
+              @source.buffer_encoding = ::Encoding::UTF_8
             end
           end
         end

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -70,11 +70,10 @@ module REXML
 
     def match(pattern, cons=false)
       if cons
-        @scanner.scan(pattern)
+        @scanner.scan(pattern).nil? ? nil : @scanner
       else
-        @scanner.check(pattern)
+        @scanner.check(pattern).nil? ? nil : @scanner
       end
-      @scanner.matched? ? [@scanner.matched, *@scanner.captures] : nil
     end
 
     # @return true if the Source is exhausted
@@ -161,24 +160,24 @@ module REXML
 
     def match( pattern, cons=false )
       if cons
-        @scanner.scan(pattern)
+        md = @scanner.scan(pattern)
       else
-        @scanner.check(pattern)
+        md = @scanner.check(pattern)
       end
-      while !@scanner.matched? and @source
+      while md.nil? and @source
         begin
           @scanner << readline
           if cons
-            @scanner.scan(pattern)
+            md = @scanner.scan(pattern)
           else
-            @scanner.check(pattern)
+            md = @scanner.check(pattern)
           end
         rescue
           @source = nil
         end
       end
 
-      @scanner.matched? ? [@scanner.matched, *@scanner.captures] : nil
+      md.nil? ? nil : @scanner
     end
 
     def empty?

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -42,6 +42,7 @@ module REXML
     # value, overriding all encoding detection
     def initialize(arg, encoding=nil)
       @orig = @buffer = arg
+      @scanner = StringScanner.new(@buffer)
       if encoding
         self.encoding = encoding
       else
@@ -62,7 +63,7 @@ module REXML
     end
 
     def match(pattern, cons=false)
-      @scanner = StringScanner.new(@buffer)
+      @scanner.string = @buffer
       @scanner.scan(pattern)
       @buffer = @scanner.rest if cons and @scanner.matched?
 
@@ -151,7 +152,7 @@ module REXML
     end
 
     def match( pattern, cons=false )
-      @scanner = StringScanner.new(@buffer)
+      @scanner.string = @buffer
       @scanner.scan(pattern)
       @buffer = @scanner.rest if cons and @scanner.matched?
       while !@scanner.matched? and @source

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -58,44 +58,7 @@ module REXML
       encoding_updated
     end
 
-    # Scans the source for a given pattern.  Note, that this is not your
-    # usual scan() method.  For one thing, the pattern argument has some
-    # requirements; for another, the source can be consumed.  You can easily
-    # confuse this method.  Originally, the patterns were easier
-    # to construct and this method more robust, because this method
-    # generated search regexps on the fly; however, this was
-    # computationally expensive and slowed down the entire REXML package
-    # considerably, since this is by far the most commonly called method.
-    # @param pattern must be a Regexp, and must be in the form of
-    # /^\s*(#{your pattern, with no groups})(.*)/.  The first group
-    # will be returned; the second group is used if the consume flag is
-    # set.
-    # @param consume if true, the pattern returned will be consumed, leaving
-    # everything after it in the Source.
-    # @return the pattern, if found, or nil if the Source is empty or the
-    # pattern is not found.
-    def scan(pattern, cons=false)
-      return nil if @buffer.nil?
-      rv = @buffer.scan(pattern)
-      @buffer = $' if cons and rv.size>0
-      rv
-    end
-
     def read
-    end
-
-    def consume( pattern )
-      @buffer = $' if pattern.match( @buffer )
-    end
-
-    def match_to( char, pattern )
-      return pattern.match(@buffer)
-    end
-
-    def match_to_consume( char, pattern )
-      md = pattern.match(@buffer)
-      @buffer = $'
-      return md
     end
 
     def match(pattern, cons=false)
@@ -107,10 +70,6 @@ module REXML
     # @return true if the Source is exhausted
     def empty?
       @buffer == ""
-    end
-
-    def position
-      @orig.index( @buffer )
     end
 
     # @return the current line in the source
@@ -181,39 +140,12 @@ module REXML
       end
     end
 
-    def scan(pattern, cons=false)
-      rv = super
-      # You'll notice that this next section is very similar to the same
-      # section in match(), but just a liiittle different.  This is
-      # because it is a touch faster to do it this way with scan()
-      # than the way match() does it; enough faster to warrant duplicating
-      # some code
-      if rv.size == 0
-        until @buffer =~ pattern or @source.nil?
-          begin
-            @buffer << readline
-          rescue Iconv::IllegalSequence
-            raise
-          rescue
-            @source = nil
-          end
-        end
-        rv = super
-      end
-      rv.taint if RUBY_VERSION < '2.7'
-      rv
-    end
-
     def read
       begin
         @buffer << readline
       rescue Exception, NameError
         @source = nil
       end
-    end
-
-    def consume( pattern )
-      match( pattern, true )
     end
 
     def match( pattern, cons=false )
@@ -234,10 +166,6 @@ module REXML
 
     def empty?
       super and ( @source.nil? || @source.eof? )
-    end
-
-    def position
-      @er_source.pos rescue 0
     end
 
     # @return the current line in the source

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -151,7 +151,8 @@ module REXML
       begin
         # NOTE: `@scanner << readline` does not free memory, so when parsing huge XML in JRuby's DOM,
         # out-of-memory error `Java::JavaLang::OutOfMemoryError: Java heap space` occurs.
-        # `@scanner.string = @scanner.rest + readline` frees memory and avoids this problem.
+        # `@scanner.string = @scanner.rest + readline` frees memory that is already consumed
+        # and avoids this problem.
         @scanner.string = @scanner.rest + readline
       rescue Exception, NameError
         @source = nil

--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -55,6 +55,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
+  spec.add_runtime_dependency("strscan", ">= 3.0.8")
+
   spec.add_development_dependency "benchmark_driver"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: false
+require 'test/unit'
+require 'rexml/document'
+
+module REXMLTests
+  class TestParseEntityDeclaration < Test::Unit::TestCase
+    private
+    def xml(internal_subset)
+      <<-XML
+<!DOCTYPE r SYSTEM "urn:x-henrikmartensson:test" [
+#{internal_subset}
+]>
+<r/>
+      XML
+    end
+
+    def parse(internal_subset)
+      REXML::Document.new(xml(internal_subset)).doctype
+    end
+
+    def test_empty
+      exception = assert_raise(REXML::ParseException) do
+        parse(<<-INTERNAL_SUBSET)
+<!ENTITY>
+        INTERNAL_SUBSET
+      end
+      assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed notation declaration: name is missing
+Line: 5
+Position: 72
+Last 80 unconsumed characters:
+ <!ENTITY>  ]> <r/>
+      DETAIL
+    end
+  end
+end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -727,7 +727,7 @@ Last 80 unconsumed characters:
       koln_iso_8859_1 = "K\xF6ln"
       koln_utf8 = "K\xc3\xb6ln"
       source = Source.new( koln_iso_8859_1, 'iso-8859-1' )
-      results = source.scan(/.*/)[0]
+      results = source.match(/.*/)[0]
       koln_utf8.force_encoding('UTF-8') if koln_utf8.respond_to?(:force_encoding)
       assert_equal koln_utf8, results
       output << results


### PR DESCRIPTION
Using StringScanner reduces the string copying process and speeds up the process.

And I removed unnecessary methods.

https://github.com/ruby/rexml/actions/runs/7549990000/job/20554906140?pr=105

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Calculating -------------------------------------
                     rexml 3.2.6      master  3.2.6(YJIT)  master(YJIT) 
                 dom       4.868       5.077        8.137         8.303 i/s -     100.000 times in 20.540529s 19.696590s 12.288900s 12.043666s
                 sax      13.597      13.953       19.206        20.948 i/s -     100.000 times in 7.354343s 7.167142s 5.206745s 4.773765s
                pull      15.641      16.918       22.266        25.378 i/s -     100.000 times in 6.393424s 5.910955s 4.491201s 3.940471s
              stream      14.339      15.844       19.810        22.206 i/s -     100.000 times in 6.973856s 6.311350s 5.047957s 4.503244s

Comparison:
                              dom
        master(YJIT):         8.3 i/s 
         3.2.6(YJIT):         8.1 i/s - 1.02x  slower
              master:         5.1 i/s - 1.64x  slower
         rexml 3.2.6:         4.9 i/s - 1.71x  slower

                              sax
        master(YJIT):        20.9 i/s 
         3.2.6(YJIT):        19.2 i/s - 1.09x  slower
              master:        14.0 i/s - 1.50x  slower
         rexml 3.2.6:        13.6 i/s - 1.54x  slower

                             pull
        master(YJIT):        25.4 i/s 
         3.2.6(YJIT):        22.3 i/s - 1.14x  slower
              master:        16.9 i/s - 1.50x  slower
         rexml 3.2.6:        15.6 i/s - 1.62x  slower

                           stream
        master(YJIT):        22.2 i/s 
         3.2.6(YJIT):        19.8 i/s - 1.12x  slower
              master:        15.8 i/s - 1.40x  slower
         rexml 3.2.6:        14.3 i/s - 1.55x  slower
```

- YJIT=ON : 1.02x - 1.14x faster
- YJIT=OFF : 1.02x - 1.10x faster