### PR TITLE
xpath: Fix normalize_space(array) case

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -262,7 +262,6 @@ module REXML
       string(string).length
     end
 
-    # UNTESTED
     def Functions::normalize_space( string=nil )
       string = string(@@context[:node]) if string.nil?
       if string.kind_of? Array

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -266,7 +266,7 @@ module REXML
     def Functions::normalize_space( string=nil )
       string = string(@@context[:node]) if string.nil?
       if string.kind_of? Array
-        string.collect{|x| string.to_s.strip.gsub(/\s+/um, ' ') if string}
+        string.collect{|x| x.to_s.strip.gsub(/\s+/um, ' ') if x}
       else
         string.to_s.strip.gsub(/\s+/um, ' ')
       end

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -229,6 +229,25 @@ module REXMLTests
       assert_equal( [REXML::Comment.new("COMMENT A")], m )
     end
 
+    def test_normalize_space2
+      source1 = "<a><b>breakfast boosts concentration</b><c>Coffee beans aroma</c><d>Dessert after dinner</d></a>"
+      source2 = <<-XML
+<a><b>breakfast     boosts\t\t
+ 
+concentration   </b><c>
+Coffee beans
+ aroma
+
+
+
+</c><d>        Dessert
+ \t\t    after    dinner</d></a>
+      XML
+      ret1 = REXML::XPath.each(REXML::Document.new(source1), "//text()").to_a
+      ret2 = REXML::XPath.each(REXML::Document.new(source2), "normalize-space(//text())").to_a
+      assert_equal( ret1, ret2 )
+    end
+
     def test_string_nil_without_context
       doc = REXML::Document.new(<<-XML)
       <?xml version="1.0" encoding="UTF-8"?>

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -229,9 +229,8 @@ module REXMLTests
       assert_equal( [REXML::Comment.new("COMMENT A")], m )
     end
 
-    def test_normalize_space2
-      source1 = "<a><b>breakfast boosts concentration</b><c>Coffee beans aroma</c><d>Dessert after dinner</d></a>"
-      source2 = <<-XML
+    def test_normalize_space_strings
+      source = <<-XML
 <a><b>breakfast     boosts\t\t
  
 concentration   </b><c>
@@ -243,9 +242,13 @@ Coffee beans
 </c><d>        Dessert
  \t\t    after    dinner</d></a>
       XML
-      ret1 = REXML::XPath.each(REXML::Document.new(source1), "//text()").to_a
-      ret2 = REXML::XPath.each(REXML::Document.new(source2), "normalize-space(//text())").to_a
-      assert_equal( ret1, ret2 )
+      normalized_texts = REXML::XPath.each(REXML::Document.new(source), "normalize-space(//text())").to_a
+      assert_equal([
+                     "breakfast boosts concentration",
+                     "Coffee beans aroma",
+                     "Dessert after dinner",
+                   ],
+                   normalized_texts)
     end
 
     def test_string_nil_without_context


### PR DESCRIPTION
GitHub: fix GH-110

Fixed a bug in `REXML::Functions.normalize_space(array)` and introduced test cases for it:

- Corrected a typo in the variable name within the collect block (`string` -> `x`).
- Added `test_normalize_space_strings` to `test/functions/test_base.rb`.
