### PR TITLE
Remove unnecessary checks in baseparser

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -420,9 +420,6 @@ module REXML
           else
             md = @source.match( TEXT_PATTERN, true )
             text = md[1]
-            if md[0].length == 0
-              @source.match( /(\s+)/, true )
-            end
             return [ :text, text ]
           end
         rescue REXML::UndefinedNamespaceException


### PR DESCRIPTION
## Why

https://github.com/ruby/rexml/blob/444c9ce7449d3c5a75ae50087555ec73ae1963a8/lib/rexml/parsers/baseparser.rb#L352-L425
```
          next_data = @source.buffer
          if next_data.size < 2
            @source.read
            next_data = @source.buffer
          end
          if next_data[0] == ?<
              :
            (omit)
              :
          else # next_data is a string of one or more characters other than '<'.
            md = @source.match( TEXT_PATTERN, true ) # TEXT_PATTERN = /\A([^<]*)/um
            text = md[1]
            if md[0].length == 0 # md[0].length is greater than or equal to 1.
              @source.match( /(\s+)/, true )
            end
```
This is an unnecessary check because md[0].length is greater than or equal to 1.