### PR TITLE
Stop specifying the gem version of strscan in benchmarks.

### DIFF
--- a/benchmark/parse.yaml
+++ b/benchmark/parse.yaml
@@ -5,8 +5,6 @@ contexts:
     require: false
     prelude: require 'rexml'
   - name: master
-    gems:
-      strscan: 3.0.9
     prelude: |
       $LOAD_PATH.unshift(File.expand_path("lib"))
       require 'rexml'
@@ -18,8 +16,6 @@ contexts:
       require 'rexml'
       RubyVM::YJIT.enable
   - name: master(YJIT)
-    gems:
-      strscan: 3.0.9
     prelude: |
       $LOAD_PATH.unshift(File.expand_path("lib"))
       require 'rexml'


### PR DESCRIPTION
## [Why]

Because benchmarks are broken when new strscan is released.

https://github.com/ruby/rexml/actions/runs/7825513689/job/21349811563

```
RUBYLIB= BUNDLER_ORIG_RUBYLIB= /opt/hostedtoolcache/Ruby/3.3.0/x64/bin/ruby -v -S benchmark-driver /home/runner/work/rexml/rexml/benchmark/parse.yaml

ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]
Calculating -------------------------------------
                     rexml 3.2.6      master  3.2.6(YJIT)  master(YJIT)
/opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/3.3.0/rubygems/dependency.rb:315:in `to_specs': Could not find 'strscan' (= 3.0.9) - did find: [strscan-3.1.0,strscan-3.0.7] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/home/runner/.local/share/gem/ruby/3.3.0:/opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/gems/3.3.0' , execute `gem env` for more information
	from /opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/3.3.0/rubygems/dependency.rb:325:in `to_spec'
	from /opt/hostedtoolcache/Ruby/3.3.0/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_gem.rb:56:in `gem'
	from /tmp/benchmark_driver-20240208-1790-njwk6u.rb:1:in `<main>'

```