### PR TITLE
test: Fix invalid XML with spaces before the XML declaration

### DIFF
--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -252,7 +252,7 @@ Coffee beans
     end
 
     def test_string_nil_without_context
-      doc = REXML::Document.new(<<-XML)
+      doc = REXML::Document.new(<<~XML)
       <?xml version="1.0" encoding="UTF-8"?>
       <root>
       <foo bar="baz"/>

--- a/test/test_contrib.rb
+++ b/test/test_contrib.rb
@@ -80,7 +80,7 @@ DELIMITER
 
     # Peter Verhage
     def test_namespace_Peter
-      source = <<-EOF
+      source = <<~EOF
       <?xml version="1.0"?>
       <config:myprog-config xmlns:config="http://someurl/program/version">
       <!-- main options -->
@@ -377,7 +377,7 @@ EOF
     end
 
     def test_entities_Holden_Glova
-      document = <<-EOL
+      document = <<~EOL
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE rubynet [
       <!ENTITY rbconfig.MAJOR "1">

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -15,7 +15,7 @@ module REXMLTests
     include Helper::Fixture
     include REXML
     def setup
-      @xsa_source = <<-EOL
+      @xsa_source = <<~EOL
         <?xml version="1.0"?>
         <?xsl stylesheet="blah.xsl"?>
         <!-- The first line tests the XMLDecl, the second tests PI.
@@ -89,7 +89,7 @@ module REXMLTests
 
       # Bryan Murphy <murphybryanp@yahoo.com>
       text = "this is a {target[@name='test']/@value} test"
-      source = <<-EOL
+      source = <<~EOL
       <?xml version="1.0"?>
       <doc search="#{text}"/>
       EOL
@@ -869,7 +869,7 @@ EOL
       assert_equal 'two', doc.root.elements[1].namespace
       assert_equal 'foo', doc.root.namespace
 
-      doc = Document.new <<-EOL
+      doc = Document.new <<~EOL
       <?xml version="1.0"?>
       <!DOCTYPE schema SYSTEM "XMLSchema.dtd" [
       <!ENTITY % p ''>
@@ -946,7 +946,7 @@ EOL
     end
 
     def test_oses_with_bad_EOLs
-      Document.new("\n\n\n<?xml version='1.0'?>\n\n\n<a/>\n\n")
+      Document.new("<?xml version='1.0'?>\n\n\n<a/>\n\n")
     end
 
     # Contributed (with patch to fix bug) by Kouhei
@@ -973,7 +973,7 @@ EOL
     end
 
     def test_hyphens_in_doctype
-      doc = REXML::Document.new <<-EOQ
+      doc = REXML::Document.new <<~EOQ
        <?xml version="1.0"?>
        <!DOCTYPE a-b-c>
        <a-b-c>
@@ -1089,7 +1089,7 @@ EOL
     def test_text_raw
       # From the REXML tutorial
       # (http://www.germane-software.com/software/rexml/test/data/tutorial.html)
-      doc = Document.new <<-EOL
+      doc = Document.new <<~EOL
       <?xml version="1.0"?>
       <!DOCTYPE schema SYSTEM "XMLSchema.dtd" [
       <!ENTITY % s 'Sean'>

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -4,7 +4,7 @@
 module REXMLTests
   class TestDocument < Test::Unit::TestCase
     def test_version_attributes_to_s
-      doc = REXML::Document.new(<<-eoxml)
+      doc = REXML::Document.new(<<~eoxml)
         <?xml version="1.0" encoding="UTF-8" standalone="no"?>
         <svg  id="svg2"
               xmlns:sodipodi="foo"

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -67,7 +67,7 @@ module REXMLTests
     # * Given an encoded document, accessing text and attribute nodes
     #   should provide UTF-8 text.
     def test_in_different_access
-      doc = Document.new <<-EOL
+      doc = Document.new <<~EOL
       <?xml version='1.0' encoding='ISO-8859-1'?>
       <a a="\xFF">\xFF</a>
       EOL
@@ -79,7 +79,7 @@ module REXMLTests
 
 
     def test_ticket_89
-      doc = Document.new <<-EOL
+      doc = Document.new <<~EOL
          <?xml version="1.0" encoding="CP-1252" ?>
          <xml><foo></foo></xml>
          EOL

--- a/test/test_sax.rb
+++ b/test/test_sax.rb
@@ -109,7 +109,7 @@ module REXMLTests
     # test simple non-entity doctype in sax listener
     # submitted by Jeff Barczewski
     def test_simple_doctype_listener
-      xml = <<-END
+      xml = <<~END
         <?xml version="1.0"?>
         <!DOCTYPE greeting PUBLIC "Hello Greeting DTD" "http://foo/hello.dtd">
         <greeting>Hello, world!</greeting>
@@ -141,7 +141,7 @@ module REXMLTests
     # test doctype with missing name, should throw ParseException
     # submitted by Jeff Barczewseki
     def test_doctype_with_mising_name_throws_exception
-      xml = <<-END
+      xml = <<~END
         <?xml version="1.0"?>
         <!DOCTYPE >
         <greeting>Hello, world!</greeting>

--- a/test/test_validation_rng.rb
+++ b/test/test_validation_rng.rb
@@ -7,7 +7,7 @@ module REXMLTests
     include REXML
 
     def test_validate
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -24,7 +24,7 @@ module REXMLTests
     </element>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A><B><C X="x"><E/><E/></C><D/></B></A>} )
@@ -33,7 +33,7 @@ module REXMLTests
 
 
     def test_sequence
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -45,7 +45,7 @@ module REXMLTests
     </element>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B><C/><C/><D/></B></A>} )
@@ -56,7 +56,7 @@ module REXMLTests
 
 
     def test_choice
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -70,7 +70,7 @@ module REXMLTests
     </choice>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B><C/><D/></B></A>} )
@@ -79,7 +79,7 @@ module REXMLTests
     end
 
     def test_optional
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -90,7 +90,7 @@ module REXMLTests
     </optional>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A><B/></A>} )
@@ -100,7 +100,7 @@ module REXMLTests
     end
 
     def test_zero_or_more
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -111,7 +111,7 @@ module REXMLTests
     </zeroOrMore>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
       no_error( validator, %q{<A><B/></A>} )
       no_error( validator, %q{<A><B><C/></B></A>} )
@@ -119,7 +119,7 @@ module REXMLTests
       error( validator, %q{<A><B><D/></B></A>} )
       error( validator, %q{<A></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -133,7 +133,7 @@ module REXMLTests
     </zeroOrMore>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A><B/></A>} )
@@ -143,7 +143,7 @@ module REXMLTests
     end
 
     def test_one_or_more
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -154,7 +154,7 @@ module REXMLTests
     </oneOrMore>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -165,13 +165,13 @@ module REXMLTests
     end
 
     def test_attribute
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <attribute name="X"/>
   <attribute name="Y"/>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -181,7 +181,7 @@ module REXMLTests
     end
 
     def test_choice_attributes
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <choice>
@@ -189,7 +189,7 @@ module REXMLTests
     <attribute name="Y"/>
   </choice>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A X="1" Y="1"/>} )
@@ -199,7 +199,7 @@ module REXMLTests
     end
 
     def test_choice_attribute_element
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <choice>
@@ -207,7 +207,7 @@ module REXMLTests
     <element name="B"/>
   </choice>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A X="1"><B/></A>} )
@@ -217,12 +217,12 @@ module REXMLTests
     end
 
     def test_empty
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <empty/>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -231,12 +231,12 @@ module REXMLTests
     end
 
     def test_text_val
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <text/>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -245,7 +245,7 @@ module REXMLTests
     end
 
     def test_choice_text
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <choice>
@@ -253,7 +253,7 @@ module REXMLTests
     <text/>
   </choice>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/>Text</A>} )
@@ -263,7 +263,7 @@ module REXMLTests
     end
 
     def test_group
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <choice>
@@ -274,7 +274,7 @@ module REXMLTests
     </group>
   </choice>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/><C/></A>} )
@@ -282,7 +282,7 @@ module REXMLTests
       no_error( validator, %q{<A><B/></A>} )
       no_error( validator, %q{<A><C/><D/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B"/>
@@ -291,7 +291,7 @@ module REXMLTests
     <element name="D"/>
   </group>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/><C/></A>} )
@@ -302,14 +302,14 @@ module REXMLTests
 
     def test_value
       # Values as text nodes
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
     <value>VaLuE</value>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B>X</B></A>} )
@@ -317,7 +317,7 @@ module REXMLTests
       no_error( validator, %q{<A><B>VaLuE</B></A>} )
 
       # Values as text nodes, via choice
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -327,7 +327,7 @@ module REXMLTests
     </choice>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -336,14 +336,14 @@ module REXMLTests
       no_error( validator, %q{<A><B>Option 2</B></A>} )
 
       # Attribute values
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <attribute name="B">
     <value>VaLuE</value>
   </attribute>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A/>} )
@@ -352,7 +352,7 @@ module REXMLTests
       no_error( validator, %q{<A B="VaLuE"/>} )
 
       # Attribute values via choice
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <attribute name="B">
@@ -362,7 +362,7 @@ module REXMLTests
     </choice>
   </attribute>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A B=""/>} )
@@ -372,7 +372,7 @@ module REXMLTests
     end
 
     def test_interleave
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -383,7 +383,7 @@ module REXMLTests
     </interleave>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B><C/></B></A>} )
@@ -396,7 +396,7 @@ module REXMLTests
     end
 
     def test_mixed
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <element name="A" xmlns="http://relaxng.org/ns/structure/1.0">
   <element name="B">
@@ -405,7 +405,7 @@ module REXMLTests
     </mixed>
   </element>
 </element>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A><B>Text<D/></B></A>} )
@@ -413,7 +413,7 @@ module REXMLTests
     end
 
     def test_ref_sequence
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -429,7 +429,7 @@ module REXMLTests
     </element>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A><B X=''/><B X=''/></A>} )
@@ -437,7 +437,7 @@ module REXMLTests
     end
 
     def test_ref_choice
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -453,7 +453,7 @@ module REXMLTests
     <element name="C"/>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><D/></A>} )
@@ -461,7 +461,7 @@ module REXMLTests
       no_error( validator, %q{<A><B/></A>} )
       no_error( validator, %q{<A><C/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -477,7 +477,7 @@ module REXMLTests
     </choice>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><D/></A>} )
@@ -485,7 +485,7 @@ module REXMLTests
       no_error( validator, %q{<A><B/></A>} )
       no_error( validator, %q{<A><C/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -502,7 +502,7 @@ module REXMLTests
     <element name="C"/>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/><C/></A>} )
@@ -513,7 +513,7 @@ module REXMLTests
 
 
     def test_ref_zero_plus
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -530,7 +530,7 @@ module REXMLTests
     </element>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -538,7 +538,7 @@ module REXMLTests
       no_error( validator, %q{<A><B X=''/></A>} )
       no_error( validator, %q{<A><B X=''/><B X=''/><B X=''/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -555,7 +555,7 @@ module REXMLTests
     </zeroOrMore>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -566,7 +566,7 @@ module REXMLTests
 
 
     def test_ref_one_plus
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -583,7 +583,7 @@ module REXMLTests
     </element>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -591,7 +591,7 @@ module REXMLTests
       no_error( validator, %q{<A><B X=''/></A>} )
       no_error( validator, %q{<A><B X=''/><B X=''/><B X=''/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -608,7 +608,7 @@ module REXMLTests
     </oneOrMore>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -618,7 +618,7 @@ module REXMLTests
     end
 
     def test_ref_interleave
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -634,7 +634,7 @@ module REXMLTests
     <element name="C"/>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -643,7 +643,7 @@ module REXMLTests
       no_error( validator, %q{<A><B/><C/></A>} )
       no_error( validator, %q{<A><C/><B/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -659,7 +659,7 @@ module REXMLTests
     </interleave>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -668,7 +668,7 @@ module REXMLTests
       no_error( validator, %q{<A><B/><C/></A>} )
       no_error( validator, %q{<A><C/><B/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -687,7 +687,7 @@ module REXMLTests
     <element name="C"/>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A><B/></A>} )
@@ -698,7 +698,7 @@ module REXMLTests
     end
 
     def test_ref_recurse
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -715,7 +715,7 @@ module REXMLTests
     </element>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       error( validator, %q{<A></A>} )
@@ -724,7 +724,7 @@ module REXMLTests
     end
 
     def test_ref_optional
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -740,7 +740,7 @@ module REXMLTests
     </element>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A></A>} )
@@ -748,7 +748,7 @@ module REXMLTests
       error( validator, %q{<A><B/><B/></A>} )
       error( validator, %q{<A><C/></A>} )
 
-      rng = %q{
+      rng = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <start>
@@ -764,7 +764,7 @@ module REXMLTests
     </optional>
   </define>
 </grammar>
-      }
+      XML
       validator = REXML::Validation::RelaxNG.new( rng )
 
       no_error( validator, %q{<A></A>} )

--- a/test/test_xml_declaration.rb
+++ b/test/test_xml_declaration.rb
@@ -6,7 +6,7 @@
 module REXMLTests
   class TestXmlDeclaration < Test::Unit::TestCase
     def setup
-      xml = <<-XML
+      xml = <<~XML
       <?xml encoding= 'UTF-8' standalone='yes'?>
       <root>
       </root>

--- a/test/xpath/test_predicate.rb
+++ b/test/xpath/test_predicate.rb
@@ -6,7 +6,7 @@ require "rexml/parsers/xpathparser"
 module REXMLTests
   class TestXPathPredicate < Test::Unit::TestCase
     include REXML
-    SRC=<<-EOL
+    SRC=<<~EOL
     <article>
        <section role="subdivision" id="1">
           <para>free flowing text.</para>


### PR DESCRIPTION
## Why?
XML declaration allowed only at the start of the document.

https://www.w3.org/TR/2006/REC-xml11-20060816/#document

```
[1]   document   ::=   ( prolog element Misc* ) - ( Char* RestrictedChar Char* ) 
```

It doesn't have `S*` before `prolog`.

https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-prolog

```
[22]   prolog   ::=   	XMLDecl Misc* (doctypedecl Misc*)?
```

It doesn't have `S*` before `XMLdecl`.

https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-XMLDecl

```
[23]   XMLDecl  ::=   '<?xml' VersionInfo EncodingDecl? SDDecl? S? '?>'
```

It doesn't have `S*` before `'<?xml'`.

