### PR TITLE
Remove `Source#string=` method

### DIFF
--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -76,8 +76,12 @@ module REXML
       end
     end
 
-    def string=(string)
-      @scanner.string = string
+    def position
+      @scanner.pos
+    end
+
+    def position=(pos)
+      @scanner.pos = pos
     end
 
     # @return true if the Source is exhausted

--- a/test/parse/test_notation_declaration.rb
+++ b/test/parse/test_notation_declaration.rb
@@ -35,7 +35,7 @@ Malformed notation declaration: name is missing
 Line: 5
 Position: 72
 Last 80 unconsumed characters:
- <!NOTATION>  ]> <r/> 
+<!NOTATION>  ]> <r/> 
         DETAIL
       end
 


### PR DESCRIPTION
## Why?

We want to just change scan pointer.

https://github.com/ruby/rexml/pull/114#discussion_r1501773803
> I want to just change scan pointer (`StringScanner#pos=`) instead of changing `@scanner.string`.