### PR TITLE
 Optimize the parse_attributes method to use `Source#match` to parse XML. 

### DIFF
--- a/test/parse/test_element.rb
+++ b/test/parse/test_element.rb
@@ -41,9 +41,9 @@ Last 80 unconsumed characters:
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Invalid attribute name: <:a="">
 Line: 1
-Position: 9
+Position: 13
 Last 80 unconsumed characters:
-
+:a=""></x>
         DETAIL
       end
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -1331,6 +1331,19 @@ Last 80 unconsumed characters:
       DETAIL
     end
 
+    def test_parse_exception_on_missing_attribute_end_quote
+      src = '<foo bar="value/>'
+      exception = assert_raise(ParseException) do
+        Document.new(src)
+      end
+      assert_equal(<<-DETAIL, exception.to_s)
+Missing attribute value end quote: <bar>: <">
+Line: 1
+Position: 17
+Last 80 unconsumed characters:
+      DETAIL
+    end
+
     def test_ticket_63
       File.open(fixture_path("t63-1.xml")) {|f| Document.new(f) }
     end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -116,11 +116,12 @@ module REXMLTests
 
     def test_attribute_namespace_conflict
       # https://www.w3.org/TR/xml-names/#uniqAttrs
-      message = <<-MESSAGE
+      message = <<-MESSAGE.chomp
 Duplicate attribute "a"
 Line: 4
 Position: 140
 Last 80 unconsumed characters:
+/>
       MESSAGE
       assert_raise(REXML::ParseException.new(message)) do
         Document.new(<<-XML)
@@ -1323,11 +1324,12 @@ EOL
       exception = assert_raise(ParseException) do
         Document.new(src)
       end
-      assert_equal(<<-DETAIL, exception.to_s)
+      assert_equal(<<-DETAIL.chomp, exception.to_s)
 Missing attribute value start quote: <bar>
 Line: 1
 Position: 16
 Last 80 unconsumed characters:
+value/>
       DETAIL
     end
 
@@ -1336,11 +1338,12 @@ Last 80 unconsumed characters:
       exception = assert_raise(ParseException) do
         Document.new(src)
       end
-      assert_equal(<<-DETAIL, exception.to_s)
+      assert_equal(<<-DETAIL.chomp, exception.to_s)
 Missing attribute value end quote: <bar>: <">
 Line: 1
 Position: 17
 Last 80 unconsumed characters:
+value/>
       DETAIL
     end
 


### PR DESCRIPTION
## Why?

Improve maintainability by consolidating processing into `Source#match`.

## [Benchmark]
```
RUBYLIB= BUNDLER_ORIG_RUBYLIB= /Users/naitoh/.rbenv/versions/3.3.0/bin/ruby -v -S benchmark-driver /Users/naitoh/ghq/github.com/naitoh/rexml/benchmark/parse.yaml
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin22]
Calculating -------------------------------------
                         before       after  before(YJIT)  after(YJIT)
                 dom     10.891      10.622        16.356       17.403 i/s -     100.000 times in 9.182130s 9.414177s 6.113806s 5.746133s
                 sax     30.335      29.845        49.749       54.877 i/s -     100.000 times in 3.296483s 3.350595s 2.010071s 1.822259s
                pull     35.514      34.801        61.123       66.908 i/s -     100.000 times in 2.815793s 2.873484s 1.636041s 1.494591s
              stream     35.141      34.475        52.110       56.836 i/s -     100.000 times in 2.845646s 2.900638s 1.919017s 1.759456s

Comparison:
                              dom
         after(YJIT):        17.4 i/s
        before(YJIT):        16.4 i/s - 1.06x  slower
              before:        10.9 i/s - 1.60x  slower
               after:        10.6 i/s - 1.64x  slower

                              sax
         after(YJIT):        54.9 i/s
        before(YJIT):        49.7 i/s - 1.10x  slower
              before:        30.3 i/s - 1.81x  slower
               after:        29.8 i/s - 1.84x  slower

                             pull
         after(YJIT):        66.9 i/s
        before(YJIT):        61.1 i/s - 1.09x  slower
              before:        35.5 i/s - 1.88x  slower
               after:        34.8 i/s - 1.92x  slower

                           stream
         after(YJIT):        56.8 i/s
        before(YJIT):        52.1 i/s - 1.09x  slower
              before:        35.1 i/s - 1.62x  slower
               after:        34.5 i/s - 1.65x  slower

```

- YJIT=ON : 1.06x - 1.10x faster
- YJIT=OFF : 0.97x - 0.98x faster