### PR TITLE
Make the test suite compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Test
         run: bundle exec rake test
 
+  frozen-string-literal:
+    name: frozen-string-literal
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rake test RUBYOPT="--enable-frozen-string-literal"
+
   gem:
     name: "Gem: ${{ matrix.ruby-version }} on ${{ matrix.runs-on }}"
     runs-on: ${{ matrix.runs-on }}

--- a/test/formatter/test_default.rb
+++ b/test/formatter/test_default.rb
@@ -2,7 +2,7 @@ module REXMLTests
   class DefaultFormatterTest < Test::Unit::TestCase
     def format(node)
       formatter = REXML::Formatters::Default.new
-      output = ""
+      output = +""
       formatter.write(node, output)
       output
     end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since `rexml` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.