### PR TITLE
Fixed a problem in which ParseException error messages could not be retrieved if the error content contained Unicode characters.

### DIFF
--- a/lib/rexml/parseexception.rb
+++ b/lib/rexml/parseexception.rb
@@ -29,6 +29,7 @@ module REXML
         err << "\nLine: #{line}\n"
         err << "Position: #{position}\n"
         err << "Last 80 unconsumed characters:\n"
+        err.force_encoding("ASCII-8BIT")
         err << @source.buffer[0..80].force_encoding("ASCII-8BIT").gsub(/\n/, ' ')
       end
 

--- a/test/parse/test_element.rb
+++ b/test/parse/test_element.rb
@@ -47,6 +47,19 @@ Last 80 unconsumed characters:
         DETAIL
       end
 
+      def test_empty_namespace_attribute_name_with_utf8_character
+        exception = assert_raise(REXML::ParseException) do
+          parse("<x :\xE2\x80\x8B>")
+        end
+        assert_equal(<<-DETAIL.chomp.force_encoding("ASCII-8BIT"), exception.to_s)
+Invalid attribute name: <:\xE2\x80\x8B>
+Line: 1
+Position: 8
+Last 80 unconsumed characters:
+:\xE2\x80\x8B>
+        DETAIL
+      end
+
       def test_garbage_less_than_before_root_element_at_line_start
         exception = assert_raise(REXML::ParseException) do
           parse("<\n<x/>")


### PR DESCRIPTION
## Why?

If the xml tag contains Unicode characters when the error occurs, an `Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT` exception is raised, ParseException error message cannot be retrieved.

See: https://github.com/ruby/rexml/issues/29