### PR TITLE
Fix the NEWS.md and change PR reference that fixes CVE-2024-35176

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,7 @@
 
   * Improved parse performance when an attribute has many `<`s.
 
-    * GH-124
+    * GH-126
 
 ### Fixes
 


### PR DESCRIPTION
It seems to me that mentioned in the NEWS.md and in the release notes PR #124 ("Move development dependencies to Gemfile") isn't a correct one and not related to CVE-2024-35176:

```
- Improved parse performance when an attribute has many <s.
  - GH-124
```

#126 looks like fixes the issue with attribute value that contains multiple '>' characters. At least it adds a proper test.