### PR TITLE
benchmark: Remove non-parsing operations from the DOM case

### DIFF
--- a/benchmark/parse.yaml
+++ b/benchmark/parse.yaml
@@ -47,7 +47,7 @@ prelude: |
   end
 
 benchmark:
-  'dom'        : REXML::Document.new(xml).elements.each("root/child") {|_|}
+  'dom'        : REXML::Document.new(xml)
   'sax'        : REXML::Parsers::SAX2Parser.new(xml).parse
   'pull'       : |
     parser = REXML::Parsers::PullParser.new(xml)


### PR DESCRIPTION
## Why?
`.elements.each("root/child") {|_|}` is not a parsing operation.

## Result
```
RUBYLIB= BUNDLER_ORIG_RUBYLIB= /Users/naitoh/.rbenv/versions/3.3.0/bin/ruby -v -S benchmark-driver /Users/naitoh/ghq/github.com/naitoh/rexml/benchmark/parse.yaml
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin22]
Calculating -------------------------------------
                         before       after  before(YJIT)  after(YJIT)
                 dom     16.254      16.412        27.189       28.940 i/s -     100.000 times in 6.152343s 6.093050s 3.677924s 3.455456s
                 sax     22.909      23.194        39.481       40.099 i/s -     100.000 times in 4.365165s 4.311414s 2.532840s 2.493807s
                pull     26.281      25.918        44.465       45.733 i/s -     100.000 times in 3.805063s 3.858328s 2.248968s 2.186621s
              stream     25.196      25.185        41.674       40.947 i/s -     100.000 times in 3.968828s 3.970585s 2.399554s 2.442158s

Comparison:
                              dom
         after(YJIT):        28.9 i/s
        before(YJIT):        27.2 i/s - 1.06x  slower
               after:        16.4 i/s - 1.76x  slower
              before:        16.3 i/s - 1.78x  slower

                              sax
         after(YJIT):        40.1 i/s
        before(YJIT):        39.5 i/s - 1.02x  slower
               after:        23.2 i/s - 1.73x  slower
              before:        22.9 i/s - 1.75x  slower

                             pull
         after(YJIT):        45.7 i/s
        before(YJIT):        44.5 i/s - 1.03x  slower
              before:        26.3 i/s - 1.74x  slower
               after:        25.9 i/s - 1.76x  slower

                           stream
        before(YJIT):        41.7 i/s
         after(YJIT):        40.9 i/s - 1.02x  slower
              before:        25.2 i/s - 1.65x  slower
               after:        25.2 i/s - 1.65x  slower

```