### PR TITLE
Add a "Malformed comment" check for invalid comments such as `<!-->`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -406,12 +406,11 @@ module REXML
               if md[0][0] == ?-
                 md = @source.match(/--(.*?)-->/um, true)
 
-                case md[1]
-                when /--/, /-\z/
+                if md.nil? || /--|-\z/.match?(md[1])
                   raise REXML::ParseException.new("Malformed comment", @source)
                 end
 
-                return [ :comment, md[1] ] if md
+                return [ :comment, md[1] ]
               else
                 md = @source.match(/\[CDATA\[(.*?)\]\]>/um, true)
                 return [ :cdata, md[1] ] if md

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -68,6 +68,19 @@ module REXMLTests
         DETAIL
       end
 
+      def test_after_doctype_malformed_comment_short
+        exception = assert_raise(REXML::ParseException) do
+          parse("<a><!-->")
+        end
+        assert_equal(<<~DETAIL.chomp, exception.to_s)
+          Malformed comment
+          Line: 1
+          Position: 8
+          Last 80 unconsumed characters:
+          -->
+        DETAIL
+      end
+
       def test_after_doctype_malformed_comment_inner
         exception = assert_raise(REXML::ParseException) do
           parse("<a><!-- -- -->")


### PR DESCRIPTION
`Document.new("<a><!-->")` raises `undefined method '[]' for nil`. This commit fixes it and adds a test for it.