### PR TITLE
Fix small typos

### DIFF
--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -237,7 +237,7 @@ EOX
       document = REXML::Document.new(xml_source)
 
       # Node#each_recursive iterates elements only.
-      # This does not iterate XML declaration, comments, attributes, CDATA sections, etc.
+      # This does not iterate XML declarations, comments, attributes, CDATA sections, etc.
       actual_names = []
       document.each_recursive do |element|
         actual_names << element.attributes["name"]

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -237,7 +237,7 @@ EOX
       document = REXML::Document.new(xml_source)
 
       # Node#each_recursive iterates elements only.
-      # This does not iterate XML declerations, comments, attributes, CDATA sections, etc.
+      # This does not iterate XML declaration, comments, attributes, CDATA sections, etc.
       actual_names = []
       document.each_recursive do |element|
         actual_names << element.attributes["name"]

--- a/test/test_light.rb
+++ b/test/test_light.rb
@@ -62,7 +62,7 @@ module REXMLTests
       assert_equal( 'c', a[1].name )
     end
 
-    def test_itterate_over_children
+    def test_iterate_over_children
       foo = make_small_document
       ctr = 0
       foo[0].each { ctr += 1 }

--- a/test/test_sax.rb
+++ b/test/test_sax.rb
@@ -140,7 +140,7 @@ module REXMLTests
 
     # test doctype with missing name, should throw ParseException
     # submitted by Jeff Barczewseki
-    def test_doctype_with_mising_name_throws_exception
+    def test_doctype_with_missing_name_throws_exception
       xml = <<~END
         <?xml version="1.0"?>
         <!DOCTYPE >

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -651,7 +651,7 @@ module REXMLTests
       source = "<a><b id='1'/><b id='2'/><b id='3'/></a>"
       doc = REXML::Document.new(source)
 
-      # NOTE TO SEE: check that number() is required
+      # NOTE: check that number() is required
       assert_equal 2, REXML::XPath.match(doc, "//b[number(@id) > 1]").size
       assert_equal 3, REXML::XPath.match(doc, "//b[number(@id) >= 1]").size
       assert_equal 1, REXML::XPath.match(doc, "//b[number(@id) <= 1]").size

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -651,7 +651,7 @@ module REXMLTests
       source = "<a><b id='1'/><b id='2'/><b id='3'/></a>"
       doc = REXML::Document.new(source)
 
-      # NOTE TO SER: check that number() is required
+      # NOTE TO SEE: check that number() is required
       assert_equal 2, REXML::XPath.match(doc, "//b[number(@id) > 1]").size
       assert_equal 3, REXML::XPath.match(doc, "//b[number(@id) >= 1]").size
       assert_equal 1, REXML::XPath.match(doc, "//b[number(@id) <= 1]").size


### PR DESCRIPTION
I found these typos with using [`typos-cli`](https://github.com/crate-ci/typos).

Now, we can obtain no typo reports from the `typos` command with this configuration (`.typos.toml`):

```toml
[files]
extend-exclude = [
  "*.svg",
  "*.xml",
]

[default.extend-words]
# Common variable names in this project.
arry = "arry"
blok = "blok"
eles = "eles"
# Incomplete words in test data.
caf = "caf"
# German words in test data.
abl = "abl" # NOTE: It is a part of "Ablüfe".
alle = "alle"
ist = "ist"
technik = "technik"
```

Thank you.