### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = "BSD-2-Clause"
 
   spec.metadata = {
-    'changelog_uri' => "#{spec.homepage}/releases/tag/v#{spec.version}"
+    "changelog_uri" => "#{spec.homepage}/releases/tag/v#{spec.version}"
   }
 
   files = [

--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/rexml"
   spec.license       = "BSD-2-Clause"
 
+  spec.metadata = {
+    'changelog_uri' => "#{spec.homepage}/releases/tag/v#{spec.version}"
+  }
+
   files = [
     "LICENSE.txt",
     "NEWS.md",


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater