### PR TITLE
Reuse of Set.new at prefixes variables

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -254,7 +254,7 @@ module REXML
                 @source.position = start_position
                 raise REXML::ParseException.new(message, @source)
               end
-              @nsstack.unshift(curr_ns=Set.new)
+              @nsstack.unshift(Set.new)
               name = parse_name(base_error_message)
               if @source.match(/\s*\[/um, true)
                 id = [nil, nil, nil]

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -138,6 +138,7 @@ module REXML
       def initialize( source )
         self.stream = source
         @listeners = []
+        @prefixes = Set.new
       end
 
       def add_listener( listener )
@@ -437,12 +438,12 @@ module REXML
               end
               tag = md[1]
               @document_status = :in_element
-              prefixes = Set.new
-              prefixes << md[2] if md[2]
+              @prefixes.clear
+              @prefixes << md[2] if md[2]
               @nsstack.unshift(curr_ns=Set.new)
-              attributes, closed = parse_attributes(prefixes, curr_ns)
+              attributes, closed = parse_attributes(@prefixes, curr_ns)
               # Verify that all of the prefixes have been defined
-              for prefix in prefixes
+              for prefix in @prefixes
                 unless @nsstack.find{|k| k.member?(prefix)}
                   raise UndefinedNamespaceException.new(prefix,@source,self)
                 end


### PR DESCRIPTION
## Why?
`Set.new()` instances of the prefixes variable can be reused, reducing initialization costs.

## Result
```
RUBYLIB= BUNDLER_ORIG_RUBYLIB= /Users/naitoh/.rbenv/versions/3.3.3/bin/ruby -v -S benchmark-driver /Users/naitoh/ghq/github.com/naitoh/rexml/benchmark/parse.yaml
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [arm64-darwin22]
Calculating -------------------------------------
                         before       after  before(YJIT)  after(YJIT)
                 dom     17.714      17.658        32.898       33.247 i/s -     100.000 times in 5.645176s 5.663160s 3.039707s 3.007755s
                 sax     25.280      25.281        47.483       49.990 i/s -     100.000 times in 3.955694s 3.955534s 2.106006s 2.000389s
                pull     29.048      29.061        59.944       61.498 i/s -     100.000 times in 3.442599s 3.441014s 1.668222s 1.626060s
              stream     28.181      28.440        52.340       55.078 i/s -     100.000 times in 3.548546s 3.516169s 1.910599s 1.815599s

Comparison:
                              dom
         after(YJIT):        33.2 i/s
        before(YJIT):        32.9 i/s - 1.01x  slower
              before:        17.7 i/s - 1.88x  slower
               after:        17.7 i/s - 1.88x  slower

                              sax
         after(YJIT):        50.0 i/s
        before(YJIT):        47.5 i/s - 1.05x  slower
               after:        25.3 i/s - 1.98x  slower
              before:        25.3 i/s - 1.98x  slower

                             pull
         after(YJIT):        61.5 i/s
        before(YJIT):        59.9 i/s - 1.03x  slower
               after:        29.1 i/s - 2.12x  slower
              before:        29.0 i/s - 2.12x  slower

                           stream
         after(YJIT):        55.1 i/s
        before(YJIT):        52.3 i/s - 1.05x  slower
               after:        28.4 i/s - 1.94x  slower
              before:        28.2 i/s - 1.95x  slower

```

YJIT=ON : 1.01x - 1.05x faster
YJIT=OFF : 0.99x - 1.00x faster