### PR TITLE
Stop adding extra new line after XML declaration with pretty format

### DIFF
--- a/lib/rexml/formatters/pretty.rb
+++ b/lib/rexml/formatters/pretty.rb
@@ -111,7 +111,7 @@ module REXML
         # itself, then we don't need a carriage return... which makes this
         # logic more complex.
         node.children.each { |child|
-          next if child == node.children[-1] and child.instance_of?(Text)
+          next if child.instance_of?(Text)
           unless child == node.children[0] or child.instance_of?(Text) or
             (child == node.children[1] and !node.children[0].writethis)
             output << "\n"

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -247,7 +247,7 @@ EOX
 
     class WriteTest < Test::Unit::TestCase
       def setup
-        @document = REXML::Document.new(<<-EOX)
+        @document = REXML::Document.new(<<-EOX.chomp)
 <?xml version="1.0" encoding="UTF-8"?>
 <message>Hello world!</message>
 EOX
@@ -257,7 +257,7 @@ EOX
         def test_output
           output = ""
           @document.write(output)
-          assert_equal(<<-EOX, output)
+          assert_equal(<<-EOX.chomp, output)
 <?xml version='1.0' encoding='UTF-8'?>
 <message>Hello world!</message>
 EOX
@@ -280,7 +280,7 @@ EOX
           indent = 2
           transitive = true
           @document.write(output, indent, transitive)
-          assert_equal(<<-EOX, output)
+          assert_equal(<<-EOX.chomp, output)
 <?xml version='1.0' encoding='UTF-8'?>
 <message
 >Hello world!</message
@@ -309,7 +309,7 @@ EOX
           japanese_text = "こんにちは"
           @document.root.text = japanese_text
           @document.write(output, indent, transitive, ie_hack, encoding)
-          assert_equal(<<-EOX.encode(encoding), output)
+          assert_equal(<<-EOX.chomp.encode(encoding), output)
 <?xml version='1.0' encoding='SHIFT_JIS'?>
 <message>#{japanese_text}</message>
 EOX
@@ -320,7 +320,7 @@ EOX
         def test_output
           output = ""
           @document.write(:output => output)
-          assert_equal(<<-EOX, output)
+          assert_equal(<<-EOX.chomp, output)
 <?xml version='1.0' encoding='UTF-8'?>
 <message>Hello world!</message>
 EOX
@@ -340,7 +340,7 @@ EOX
         def test_transitive
           output = ""
           @document.write(:output => output, :indent => 2, :transitive => true)
-          assert_equal(<<-EOX, output)
+          assert_equal(<<-EOX.chomp, output)
 <?xml version='1.0' encoding='UTF-8'?>
 <message
 >Hello world!</message
@@ -362,7 +362,7 @@ EOX
           japanese_text = "こんにちは"
           @document.root.text = japanese_text
           @document.write(:output => output, :encoding => encoding)
-          assert_equal(<<-EOX.encode(encoding), output)
+          assert_equal(<<-EOX.chomp.encode(encoding), output)
 <?xml version='1.0' encoding='SHIFT_JIS'?>
 <message>#{japanese_text}</message>
 EOX


### PR DESCRIPTION
If the XML file does not end with a newline, a space is added to the end of the first line.

```ruby
Failure: test_indent(REXMLTests::TestDocument::WriteTest::ArgumentsTest)
/Users/naitoh/ghq/github.com/naitoh/rexml/test/test_document.rb:270:in `test_indent'
     267:           output = ""
     268:           indent = 2
     269:           @document.write(output, indent)
  => 270:           assert_equal(<<-EOX.chomp, output)
     271: <?xml version='1.0' encoding='UTF-8'?>
     272: <message>
     273:   Hello world!
<"<?xml version='1.0' encoding='UTF-8'?>\n" +
"<message>\n" +
"  Hello world!\n" +
"</message>"> expected but was
<"<?xml version='1.0' encoding='UTF-8'?> \n" +
"<message>\n" +
"  Hello world!\n" +
"</message>">

diff:
? <?xml version='1.0' encoding='UTF-8'?>
  <message>
    Hello world!
  </message>

```

This is happen because `REXML::Formatters::Pretty#write_document` has a logic that depends on the last text node.

We should ignore all top-level text nodes with pretty format.