### PR TITLE
Add tests for REXML::Text.check

### DIFF
--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -68,21 +68,6 @@ module REXMLTests
         assert_check_failed('&#8;', '&#8;')
       end
 
-      def test_character_reference_format_without_hash
-        # U+0030 DIGIT ZERO
-        assert_check_failed('&48;', '&')
-      end
-
-      def test_character_reference_format_without_hash_and_start_0
-        # U+0030 DIGIT ZERO
-        assert_check_failed('&048;', '&')
-      end
-
-      def test_character_reference_format_without_hash_and_start_00
-        # U+0030 DIGIT ZERO
-        assert_check_failed('&0048;', '&')
-      end
-
       def test_character_reference_format_hex_0x
         # U+0041 LATIN CAPITAL LETTER A
         assert_check_failed('&#0x41;', '&#0x41;')

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -55,6 +55,10 @@ module REXMLTests
         assert_check_failed('<;', '<')
       end
 
+      def test_lt_mix
+        assert_check_failed('ab<cd', '<')
+      end
+
       def test_entity_reference_missing_colon
         assert_check_failed('&amp', '&')
       end
@@ -62,6 +66,31 @@ module REXMLTests
       def test_character_reference_decimal_invalid_value
         # U+0008 BACKSPACE
         assert_check_failed('&#8;', '&#8;')
+      end
+
+      def test_character_reference_format_without_hash
+        # U+0030 DIGIT ZERO
+        assert_check_failed('&48;', '&')
+      end
+
+      def test_character_reference_format_without_hash_and_start_0
+        # U+0030 DIGIT ZERO
+        assert_check_failed('&048;', '&')
+      end
+
+      def test_character_reference_format_without_hash_and_start_00
+        # U+0030 DIGIT ZERO
+        assert_check_failed('&0048;', '&')
+      end
+
+      def test_character_reference_format_hex_0x
+        # U+0041 LATIN CAPITAL LETTER A
+        assert_check_failed('&#0x41;', '&#0x41;')
+      end
+
+      def test_character_reference_format_hex_00x
+        # U+0041 LATIN CAPITAL LETTER A
+        assert_check_failed('&#00x41;', '&#00x41;')
       end
 
       def test_character_reference_hex_invalid_value

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -40,6 +40,10 @@ module REXMLTests
         # U+3044 HIRAGANA LETTER I
         assert_nothing_raised { check("&\u3042\u3044;") }
       end
+
+      def test_normal_string
+        assert_nothing_raised { check("foo") }
+      end
     end
 
     class TestInvalid < self

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -60,14 +60,17 @@ module REXMLTests
       end
 
       def test_character_reference_decimal_invalid_value
+        # U+0008 BACKSPACE
         assert_check_failed('&#8;', '&#8;')
       end
 
       def test_character_reference_hex_invalid_value
+        # U+0D800 SURROGATE PAIR
         assert_check_failed('&#xD800;', '&#xD800;')
       end
 
       def test_entity_name_non_ascii_invalid_value
+        # U+00BF INVERTED QUESTION MARK
         assert_check_failed('&\u00BF;', '&')
       end
     end

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: false
+
+module REXMLTests
+  class TextCheckTester < Test::Unit::TestCase
+    include REXML
+
+    def test_valid_pattern
+      chars = ['&A;', '&:;', '&_;', '&:A;', '&AA.bb-00;']
+      chars.each do |token|
+        text = Text.new(token, false, nil, true)
+        assert_equal(token, text.to_s)
+      end
+
+      character_entities = ['&amp;', '&lt;', '&gt;', '&quot;', '&apos;', '&nbsp;', '&Psi;']
+      character_entities.each do |token|
+        text = Text.new(token, false, nil, true)
+        assert_equal(token, text.to_s)
+      end
+
+      numeric_entities = ['&#13;', '&#34;', '&#9830;', '&#0000000013;', '&#0000000162;', '&#x10FFFF;', '&#1114111;']
+      numeric_entities.each do |token|
+        text = Text.new(token, false, nil, true)
+        assert_equal(token, text.to_s)
+      end
+
+      unicode_entities = ['&#x9;', '&#xa;', '&#xD;', '&#x84;', '&#x9F;', '&#xFDEF;', '&#x10FFFF;', '&#x000000007f;']
+      unicode_entities.each do |token|
+        text = Text.new(token, false, nil, true)
+        assert_equal(token, text.to_s)
+      end
+
+      unicodes = ["&\u00C0;", "&\uFDF0;", "&\u{10000};", "&\u00D6\u0300\u0300;"]
+      unicodes.each do |token|
+        text = Text.new(token, false, nil, true)
+        assert_equal(token, text.to_s)
+      end
+    end
+
+    def test_invalid_pattern
+      chars = ['<', '<;', '&amp', '&42;','&#A;', '&#8;', '&#xB;', '&#x1f;', '&#xD800;', '&#xFFFE;', '&#x110000;', '&#1114112;']
+      chars.each do |token|
+        assert_raise(RuntimeError) { Text.new(token, false, nil, true) }
+      end
+
+      unicodes = ["&\u00BF;", "&\u{F0000};"]
+      unicodes.each do |token|
+        assert_raise(RuntimeError) { Text.new(token, false, nil, true) }
+      end
+    end
+  end
+end

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -29,7 +29,9 @@ module REXMLTests
       end
 
       def test_entity_name_non_ascii
-        assert_nothing_raised { check("&\u00D6\u0300\u0300;") }
+        # U+3042 HIRAGANA LETTER A
+        # U+3044 HIRAGANA LETTER I
+        assert_nothing_raised { check("&\u3042\u3044;") }
       end
     end
 

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -7,6 +7,10 @@ module REXMLTests
       REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK, nil)
     end
 
+    def assert_check(string)
+      assert_nothing_raised { REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK, nil) }
+    end
+
     def assert_check_failed(string, illegal_part)
       message = "Illegal character #{illegal_part.inspect} in raw string #{string.inspect}"
       assert_raise(RuntimeError.new(message)) do
@@ -16,33 +20,33 @@ module REXMLTests
 
     class TestValid < self
       def test_entity_name_start_char_colon
-        assert_nothing_raised { check('&:;') }
+        assert_check('&:;')
       end
 
       def test_entity_name_start_char_under_score
-        assert_nothing_raised { check('&_;') }
+        assert_check('&_;')
       end
 
       def test_entity_name_mix
-        assert_nothing_raised { check('&A.b-0123;') }
+        assert_check('&A.b-0123;')
       end
 
       def test_character_reference_decimal
-        assert_nothing_raised { check('&#0162;') }
+        assert_check('&#0162;')
       end
 
       def test_character_reference_hex
-        assert_nothing_raised { check('&#x10FFFF;') }
+        assert_check('&#x10FFFF;')
       end
 
       def test_entity_name_non_ascii
         # U+3042 HIRAGANA LETTER A
         # U+3044 HIRAGANA LETTER I
-        assert_nothing_raised { check("&\u3042\u3044;") }
+        assert_check("&\u3042\u3044;")
       end
 
       def test_normal_string
-        assert_nothing_raised { check("foo") }
+        assert_check("foo")
       end
     end
 

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -7,6 +7,13 @@ module REXMLTests
       REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK, nil)
     end
 
+    def assert_check_failed(string, illegal_part)
+      message = "Illegal character #{illegal_part.inspect} in raw string #{string.inspect}"
+      assert_raise(RuntimeError.new(message)) do
+        check(string)
+      end
+    end
+
     class TestValid < self
       def test_entity_name_start_char_colon
         assert_nothing_raised { check('&:;') }
@@ -37,28 +44,23 @@ module REXMLTests
 
     class TestInvalid < self
       def test_lt
-        string = "<;"
-        assert_raise(RuntimeError.new("Illegal character \"<\" in raw string #{string.inspect}")) { check(string) }
+        assert_check_failed('<;', '<')
       end
 
       def test_entity_reference_missing_colon
-        string = "&amp"
-        assert_raise(RuntimeError.new("Illegal character \"&\" in raw string #{string.inspect}")) { check(string) }
+        assert_check_failed('&amp', '&')
       end
 
       def test_character_reference_decimal_invalid_value
-        string = "&#8;"
-        assert_raise(RuntimeError.new("Illegal character #{string.inspect} in raw string #{string.inspect}")) { check(string) }
+        assert_check_failed('&#8;', '&#8;')
       end
 
       def test_character_reference_hex_invalid_value
-        string = "&#xD800;"
-        assert_raise(RuntimeError.new("Illegal character #{string.inspect} in raw string #{string.inspect}")) { check(string) }
+        assert_check_failed('&#xD800;', '&#xD800;')
       end
 
       def test_entity_name_non_ascii_invalid_value
-        string = "&\u00BF;"
-        assert_raise(RuntimeError.new("Illegal character \"&\" in raw string #{string.inspect}")) { check(string) }
+        assert_check_failed('&\u00BF;', '&')
       end
     end
   end

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -16,19 +16,19 @@ module REXMLTests
         assert_nothing_raised { check('&_;') }
       end
 
-      def test_entity_name_char
+      def test_entity_name_mix
         assert_nothing_raised { check('&A.b-0123;') }
       end
 
-      def test_numeric_entity_decimal
+      def test_character_reference_decimal
         assert_nothing_raised { check('&#0162;') }
       end
 
-      def test_numeric_entity_hex
+      def test_character_reference_hex
         assert_nothing_raised { check('&#x10FFFF;') }
       end
 
-      def test_unicode_entity
+      def test_entity_name_non_ascii
         assert_nothing_raised { check("&\u00D6\u0300\u0300;") }
       end
     end
@@ -39,22 +39,22 @@ module REXMLTests
         assert_raise(RuntimeError.new("Illegal character \"<\" in raw string #{string.inspect}")) { check(string) }
       end
 
-      def test_missing_colon
+      def test_entity_reference_missing_colon
         string = "&amp"
         assert_raise(RuntimeError.new("Illegal character \"&\" in raw string #{string.inspect}")) { check(string) }
       end
 
-      def test_invalid_numeric_entity_decimal
+      def test_character_reference_decimal_invalid_value
         string = "&#8;"
         assert_raise(RuntimeError.new("Illegal character #{string.inspect} in raw string #{string.inspect}")) { check(string) }
       end
 
-      def test_invalid_numeric_entity_hex
+      def test_character_reference_hex_invalid_value
         string = "&#xD800;"
         assert_raise(RuntimeError.new("Illegal character #{string.inspect} in raw string #{string.inspect}")) { check(string) }
       end
 
-      def test_invalid_unicode
+      def test_entity_name_non_ascii_invalid_value
         string = "&\u00BF;"
         assert_raise(RuntimeError.new("Illegal character \"&\" in raw string #{string.inspect}")) { check(string) }
       end

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -9,39 +9,27 @@ module REXMLTests
 
     class TestValid < self
       def test_entity_name_start_char_colon
-        string = '&:;'
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check('&:;') }
       end
 
       def test_entity_name_start_char_under_score
-        string = '&_;'
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check('&_;') }
       end
 
       def test_entity_name_char
-        string = '&A.b-0123;'
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check('&A.b-0123;') }
       end
 
       def test_numeric_entity_decimal
-        string = '&#0162;'
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check('&#0162;') }
       end
 
       def test_numeric_entity_hex
-        string = '&#x10FFFF;'
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check('&#x10FFFF;') }
       end
 
       def test_unicode_entity
-        string = "&\u00D6\u0300\u0300;"
-        text = check(string)
-        assert_equal(string, text.to_s)
+        assert_nothing_raised { check("&\u00D6\u0300\u0300;") }
       end
     end
 

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -8,7 +8,7 @@ module REXMLTests
     end
 
     def assert_check(string)
-      assert_nothing_raised { REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK, nil) }
+      assert_nothing_raised { check(string) }
     end
 
     def assert_check_failed(string, illegal_part)

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -78,12 +78,12 @@ module REXMLTests
         assert_check_failed('&#00x41;', '&#00x41;')
       end
 
-      def test_character_reference_hex_invalid_value
+      def test_character_reference_hex_surrogate_block
         # U+0D800 SURROGATE PAIR
         assert_check_failed('&#xD800;', '&#xD800;')
       end
 
-      def test_entity_name_non_ascii_invalid_value
+      def test_entity_name_non_ascii_symbol
         # U+00BF INVERTED QUESTION MARK
         assert_check_failed('&\u00BF;', '&')
       end


### PR DESCRIPTION
This patch will add missing REXML::Text.check tests.

 This is the tests for the part that is checked using a regular expression:
 https://github.com/ruby/rexml/blob/b2ec329dc1dc7635b224a6d61687c24b1e1db6fd/lib/rexml/text.rb#L155-L172