### PR TITLE
Fix test for Text.check

### DIFF
--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -20,23 +20,23 @@ module REXMLTests
 
     class TestValid < self
       def test_entity_name_start_char_colon
-        assert_check('&:;')
+        assert_check("&:;")
       end
 
       def test_entity_name_start_char_under_score
-        assert_check('&_;')
+        assert_check("&_;")
       end
 
       def test_entity_name_mix
-        assert_check('&A.b-0123;')
+        assert_check("&A.b-0123;")
       end
 
       def test_character_reference_decimal
-        assert_check('&#0162;')
+        assert_check("&#0162;")
       end
 
       def test_character_reference_hex
-        assert_check('&#x10FFFF;')
+        assert_check("&#x10FFFF;")
       end
 
       def test_entity_name_non_ascii
@@ -52,40 +52,40 @@ module REXMLTests
 
     class TestInvalid < self
       def test_lt
-        assert_check_failed('<;', '<')
+        assert_check_failed("<;", "<")
       end
 
       def test_lt_mix
-        assert_check_failed('ab<cd', '<')
+        assert_check_failed("ab<cd", "<")
       end
 
       def test_entity_reference_missing_colon
-        assert_check_failed('&amp', '&')
+        assert_check_failed("&amp", "&")
       end
 
       def test_character_reference_decimal_invalid_value
         # U+0008 BACKSPACE
-        assert_check_failed('&#8;', '&#8;')
+        assert_check_failed("&#8;", "&#8;")
       end
 
       def test_character_reference_format_hex_0x
         # U+0041 LATIN CAPITAL LETTER A
-        assert_check_failed('&#0x41;', '&#0x41;')
+        assert_check_failed("&#0x41;", "&#0x41;")
       end
 
       def test_character_reference_format_hex_00x
         # U+0041 LATIN CAPITAL LETTER A
-        assert_check_failed('&#00x41;', '&#00x41;')
+        assert_check_failed("&#00x41;", "&#00x41;")
       end
 
       def test_character_reference_hex_surrogate_block
         # U+0D800 SURROGATE PAIR
-        assert_check_failed('&#xD800;', '&#xD800;')
+        assert_check_failed("&#xD800;", "&#xD800;")
       end
 
       def test_entity_name_non_ascii_symbol
         # U+00BF INVERTED QUESTION MARK
-        assert_check_failed('&\u00BF;', '&')
+        assert_check_failed("&\u00BF;", "&")
       end
     end
   end


### PR DESCRIPTION
This patch will fix incorrect string in a case where unicode characters.
Because of the use of single quotes, it was simply an ASCII string.