### PR TITLE
Fix ReDoS caused by very large character references using repeated 0s

### DIFF
--- a/test/parse/test_character_reference.rb
+++ b/test/parse/test_character_reference.rb
@@ -7,7 +7,7 @@ module REXMLTests
   class TestParseCharacterReference < Test::Unit::TestCase
     include Test::Unit::CoreAssertions
 
-    def test_gt_linear_performance_character_reference
+    def test_gt_linear_performance_many_preceding_zeros
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<test testing="&#' + "0" * n + '97;"/>')

--- a/test/parse/test_character_reference.rb
+++ b/test/parse/test_character_reference.rb
@@ -7,13 +7,10 @@ module REXMLTests
   class TestParseCharacterReference < Test::Unit::TestCase
     include Test::Unit::CoreAssertions
 
-    def test_gt_linear_performance_malformed_character_reference
+    def test_gt_linear_performance_character_reference
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        begin
-          REXML::Document.new('<test testing="&#' + "0" * n + '"/>')
-        rescue
-        end
+        REXML::Document.new('<test testing="&#' + "0" * n + '97;"/>')
       end
     end
   end

--- a/test/parse/test_character_reference.rb
+++ b/test/parse/test_character_reference.rb
@@ -1,0 +1,20 @@
+require "test/unit"
+require "core_assertions"
+
+require "rexml/document"
+
+module REXMLTests
+  class TestParseCharacterReference < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
+    def test_gt_linear_performance_malformed_character_reference
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        begin
+          REXML::Document.new('<test testing="&#' + "0" * n + '"/>')
+        rescue
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch will fix the ReDoS that is caused by large string of 0s on a character reference (like `&#00000000...`).

This is occurred in Ruby 3.1 or earlier.