### PR TITLE
Fix performance issue caused by using repeated `>` characters inside `<?xml`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -125,6 +125,7 @@ module REXML
 
       module Private
         INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
+        INSTRUCTION_TERM = "?>"
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
         CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
         ATTLISTDECL_END = /\s+#{NAME}(?:#{ATTDEF})*\s*>/um
@@ -639,7 +640,7 @@ module REXML
       end
 
       def process_instruction(start_position)
-        match_data = @source.match(Private::INSTRUCTION_END, true)
+        match_data = @source.match(Private::INSTRUCTION_END, true, term: Private::INSTRUCTION_TERM)
         unless match_data
           message = "Invalid processing instruction node"
           @source.position = start_position

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -117,7 +117,7 @@ module REXML
     def ensure_buffer
     end
 
-    def match(pattern, cons=false)
+    def match(pattern, cons=false, term: nil)
       if cons
         @scanner.scan(pattern).nil? ? nil : @scanner
       else
@@ -240,7 +240,7 @@ module REXML
     # Note: When specifying a string for 'pattern', it must not include '>' except in the following formats:
     # - ">"
     # - "XXX>" (X is any string excluding '>')
-    def match( pattern, cons=false )
+    def match( pattern, cons=false, term: nil )
       while true
         if cons
           md = @scanner.scan(pattern)
@@ -250,7 +250,7 @@ module REXML
         break if md
         return nil if pattern.is_a?(String)
         return nil if @source.nil?
-        return nil unless read
+        return nil unless read(term)
       end
 
       md.nil? ? nil : @scanner

--- a/test/parse/test_processing_instruction.rb
+++ b/test/parse/test_processing_instruction.rb
@@ -74,7 +74,7 @@ x<?x y
       assert_equal("abc", events[:processing_instruction])
     end
 
-    def test_gt_linear_performance_introduction
+    def test_gt_linear_performance
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<?xml version="1.0" ' + ">" * n + ' ?>')

--- a/test/parse/test_processing_instruction.rb
+++ b/test/parse/test_processing_instruction.rb
@@ -1,8 +1,12 @@
 require "test/unit"
+require "core_assertions"
+
 require "rexml/document"
 
 module REXMLTests
   class TestParseProcessinInstruction < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
     def parse(xml)
       REXML::Document.new(xml)
     end
@@ -68,6 +72,13 @@ x<?x y
       end
 
       assert_equal("abc", events[:processing_instruction])
+    end
+
+    def test_gt_linear_performance_introduction
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<?xml version="1.0" ' + ">" * n + ' ?>')
+      end
     end
   end
 end


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.
