### PR TITLE
Fix performance issue caused by using repeated `>` characters inside comments

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -126,6 +126,7 @@ module REXML
       module Private
         INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
         INSTRUCTION_TERM = "?>"
+        COMMENT_TERM = "-->"
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
         CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
         ATTLISTDECL_END = /\s+#{NAME}(?:#{ATTDEF})*\s*>/um
@@ -243,7 +244,7 @@ module REXML
             return process_instruction(start_position)
           elsif @source.match("<!", true)
             if @source.match("--", true)
-              md = @source.match(/(.*?)-->/um, true)
+              md = @source.match(/(.*?)-->/um, true, term: Private::COMMENT_TERM)
               if md.nil?
                 raise REXML::ParseException.new("Unclosed comment", @source)
               end

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -122,7 +122,7 @@ module REXMLTests
       assert_equal(" ok comment ", events[:comment])
     end
 
-    def test_gt_linear_performance_comment
+    def test_gt_linear_performance
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<!-- ' + ">" * n + ' -->')

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -1,8 +1,12 @@
 require "test/unit"
+require "core_assertions"
+
 require "rexml/document"
 
 module REXMLTests
   class TestParseComment < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
     def parse(xml)
       REXML::Document.new(xml)
     end
@@ -116,6 +120,13 @@ module REXMLTests
       end
 
       assert_equal(" ok comment ", events[:comment])
+    end
+
+    def test_gt_linear_performance_comment
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<!-- ' + ">" * n + ' -->')
+      end
     end
   end
 end


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.