### PR TITLE
Fix performance issue caused by using repeated `>` characters inside `CDATA [ PAYLOAD ]`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -127,6 +127,7 @@ module REXML
         INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
         INSTRUCTION_TERM = "?>"
         COMMENT_TERM = "-->"
+        CDATA_TERM = "]]>"
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
         CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
         ATTLISTDECL_END = /\s+#{NAME}(?:#{ATTDEF})*\s*>/um
@@ -431,7 +432,7 @@ module REXML
 
                 return [ :comment, md[1] ]
               else
-                md = @source.match(/\[CDATA\[(.*?)\]\]>/um, true)
+                md = @source.match(/\[CDATA\[(.*?)\]\]>/um, true, term: Private::CDATA_TERM)
                 return [ :cdata, md[1] ] if md
               end
               raise REXML::ParseException.new( "Declarations can only occur "+

--- a/test/parse/test_cdata.rb
+++ b/test/parse/test_cdata.rb
@@ -1,0 +1,17 @@
+require "test/unit"
+require "core_assertions"
+
+require "rexml/document"
+
+module REXMLTests
+  class TestParseCData < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
+    def test_gt_linear_performance_cdata
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<description><![CDATA[ ' + ">" * n + ' ]]></description>')
+      end
+    end
+  end
+end

--- a/test/parse/test_cdata.rb
+++ b/test/parse/test_cdata.rb
@@ -7,7 +7,7 @@ module REXMLTests
   class TestParseCData < Test::Unit::TestCase
     include Test::Unit::CoreAssertions
 
-    def test_gt_linear_performance_cdata
+    def test_gt_linear_performance
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<description><![CDATA[ ' + ">" * n + ' ]]></description>')


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.