### PR TITLE
Fix performance issue caused by using repeated `>` characters inside `<!DOCTYPE root [<!-- PAYLOAD -->]>`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -378,7 +378,7 @@ module REXML
                 raise REXML::ParseException.new(message, @source)
               end
               return [:notationdecl, name, *id]
-            elsif md = @source.match(/--(.*?)-->/um, true)
+            elsif md = @source.match(/--(.*?)-->/um, true, term: Private::COMMENT_TERM)
               case md[1]
               when /--/, /-\z/
                 raise REXML::ParseException.new("Malformed comment", @source)

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -290,6 +290,13 @@ x'>  <r/>
         end
       end
 
+      def test_gt_linear_performance_comment
+        seq = [10000, 50000, 100000, 150000, 200000]
+        assert_linear_performance(seq, rehearsal: 10) do |n|
+          REXML::Document.new('<!DOCTYPE root [<!-- ' + ">" * n + ' -->]>')
+        end
+      end
+
       private
       def parse(internal_subset)
         super(<<-DOCTYPE)


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.