### PR TITLE
Fix performance issue caused by using repeated `>` characters inside `<!DOCTYPE name [<!ENTITY>]>`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -124,11 +124,15 @@ module REXML
       }
 
       module Private
-        INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
+        # Terminal requires two or more letters.
         INSTRUCTION_TERM = "?>"
         COMMENT_TERM = "-->"
         CDATA_TERM = "]]>"
         DOCTYPE_TERM = "]>"
+        # Read to the end of DOCTYPE because there is no proper ENTITY termination
+        ENTITY_TERM = DOCTYPE_TERM
+
+        INSTRUCTION_END = /#{NAME}(\s+.*?)?\?>/um
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
         CLOSE_PATTERN = /(#{QNAME_STR})\s*>/um
         ATTLISTDECL_END = /\s+#{NAME}(?:#{ATTDEF})*\s*>/um
@@ -313,7 +317,7 @@ module REXML
               raise REXML::ParseException.new( "Bad ELEMENT declaration!", @source ) if md.nil?
               return [ :elementdecl, "<!ELEMENT" + md[1] ]
             elsif @source.match("ENTITY", true)
-              match = [:entitydecl, *@source.match(Private::ENTITYDECL_PATTERN, true).captures.compact]
+              match = [:entitydecl, *@source.match(Private::ENTITYDECL_PATTERN, true, term: Private::ENTITY_TERM).captures.compact]
               ref = false
               if match[1] == '%'
                 ref = true

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -33,7 +33,7 @@ Last 80 unconsumed characters:
       DETAIL
     end
 
-    def test_gt_linear_performance_entity
+    def test_gt_linear_performance
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">')

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -32,5 +32,12 @@ Last 80 unconsumed characters:
  <!ENTITY>  ]> <r/>
       DETAIL
     end
+
+    def test_gt_linear_performance_entity
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">')
+      end
+    end
   end
 end


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.