### PR TITLE
Fix ReDoS by using repeated space characters inside `<!DOCTYPE name [<!ATTLIST>]>`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -349,7 +349,7 @@ module REXML
               contents = md[0]
 
               pairs = {}
-              values = md[0].scan( ATTDEF_RE )
+              values = md[0].strip.scan( ATTDEF_RE )
               values.each do |attdef|
                 unless attdef[3] == "#IMPLIED"
                   attdef.compact!

--- a/test/parse/test_attlist.rb
+++ b/test/parse/test_attlist.rb
@@ -7,7 +7,7 @@ module REXMLTests
   class TestParseAttlist < Test::Unit::TestCase
     include Test::Unit::CoreAssertions
 
-    def test_gt_linear_performance_attlist
+    def test_gt_linear_performance
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<!DOCTYPE schema SYSTEM "foo.dtd" [<!ATTLIST ' + " " * n + ' root v CDATA #FIXED "test">]>')

--- a/test/parse/test_attlist.rb
+++ b/test/parse/test_attlist.rb
@@ -1,0 +1,17 @@
+require "test/unit"
+require "core_assertions"
+
+require "rexml/document"
+
+module REXMLTests
+  class TestParseAttlist < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
+    def test_gt_linear_performance_attlist
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<!DOCTYPE schema SYSTEM "foo.dtd" [<!ATTLIST ' + " " * n + ' root v CDATA #FIXED "test">]>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix performance by removing unnecessary spaces.

This is occurred in Ruby 3.1 or earlier.