### PR TITLE
Fix performance issue caused by using repeated `>` characters inside `<xml><!-- --></xml>`

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -429,7 +429,7 @@ module REXML
               #STDERR.puts "SOURCE BUFFER = #{source.buffer}, #{source.buffer.size}"
               raise REXML::ParseException.new("Malformed node", @source) unless md
               if md[0][0] == ?-
-                md = @source.match(/--(.*?)-->/um, true)
+                md = @source.match(/--(.*?)-->/um, true, term: Private::COMMENT_TERM)
 
                 if md.nil? || /--|-\z/.match?(md[1])
                   raise REXML::ParseException.new("Malformed comment", @source)

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -129,7 +129,7 @@ module REXMLTests
       end
     end
 
-    def test_gt_linear_performance_comment_in_element
+    def test_gt_linear_performance_in_element
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new('<xml><!-- ' + '>' * n + ' --></xml>')

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -128,5 +128,12 @@ module REXMLTests
         REXML::Document.new('<!-- ' + ">" * n + ' -->')
       end
     end
+
+    def test_gt_linear_performance_comment_in_element
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        REXML::Document.new('<xml><!-- ' + '>' * n + ' --></xml>')
+      end
+    end
   end
 end


### PR DESCRIPTION
A `<` is treated as a string delimiter. 
In certain cases, if `<` is used in succession, read and match are repeated, which slows down the process. Therefore, the following is used to read ahead to a specific part of the string in advance.