### PR TITLE
Fix method scope in test in order to invoke the tests properly and fix exception message

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -318,11 +318,11 @@ module REXML
               raise REXML::ParseException.new( "Bad ELEMENT declaration!", @source ) if md.nil?
               return [ :elementdecl, "<!ELEMENT" + md[1] ]
             elsif @source.match("ENTITY", true)
-              scanner = @source.match(Private::ENTITYDECL_PATTERN, true, term: Private::ENTITY_TERM)
-              unless scanner
+              match_data = @source.match(Private::ENTITYDECL_PATTERN, true, term: Private::ENTITY_TERM)
+              unless match_data
                 raise REXML::ParseException.new("Malformed entity declaration", @source)
               end
-              match = [:entitydecl, *scanner.captures.compact]
+              match = [:entitydecl, *match_data.captures.compact]
               ref = false
               if match[1] == '%'
                 ref = true

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -318,7 +318,11 @@ module REXML
               raise REXML::ParseException.new( "Bad ELEMENT declaration!", @source ) if md.nil?
               return [ :elementdecl, "<!ELEMENT" + md[1] ]
             elsif @source.match("ENTITY", true)
-              match = [:entitydecl, *@source.match(Private::ENTITYDECL_PATTERN, true, term: Private::ENTITY_TERM).captures.compact]
+              scanner = @source.match(Private::ENTITYDECL_PATTERN, true, term: Private::ENTITY_TERM)
+              unless scanner
+                raise REXML::ParseException.new("Malformed entity declaration", @source)
+              end
+              match = [:entitydecl, *scanner.captures.compact]
               ref = false
               if match[1] == '%'
                 ref = true

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -24,11 +24,18 @@ module REXMLTests
 
     public
     def test_empty
-      assert_raise(REXML::ParseException) do
+      exception = assert_raise(REXML::ParseException) do
         parse(<<-INTERNAL_SUBSET)
 <!ENTITY>
         INTERNAL_SUBSET
       end
+      assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 5
+Position: 70
+Last 80 unconsumed characters:
+>  ]> <r/> 
+      DETAIL
     end
 
     def test_linear_performance_gt

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: false
-require 'test/unit'
-require 'rexml/document'
+require "test/unit"
+require "core_assertions"
+
+require "rexml/document"
 
 module REXMLTests
   class TestParseEntityDeclaration < Test::Unit::TestCase
+    include Test::Unit::CoreAssertions
+
     private
     def xml(internal_subset)
       <<-XML
@@ -18,25 +22,22 @@ module REXMLTests
       REXML::Document.new(xml(internal_subset)).doctype
     end
 
+    public
     def test_empty
-      exception = assert_raise(REXML::ParseException) do
+      assert_raise(REXML::ParseException) do
         parse(<<-INTERNAL_SUBSET)
 <!ENTITY>
         INTERNAL_SUBSET
       end
-      assert_equal(<<-DETAIL.chomp, exception.to_s)
-Malformed notation declaration: name is missing
-Line: 5
-Position: 72
-Last 80 unconsumed characters:
- <!ENTITY>  ]> <r/>
-      DETAIL
     end
 
     def test_linear_performance_gt
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">')
+        begin
+          REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">')
+        rescue
+        end
       end
     end
   end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -34,10 +34,7 @@ module REXMLTests
     def test_linear_performance_gt
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        begin
-          REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">')
-        rescue
-        end
+        REXML::Document.new('<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version "' + '>' * n + '">]>')
       end
     end
   end


### PR DESCRIPTION
This PR includes following two fixes.

1. The `test_empty` and `test_linear_performance_gt` were defined as private method. Seems that test-unit runner does not invoke private methods even if the methods have `test_` prefix.
2. When parse malformed entity declaration, the exception might have the message about `NoMethodError`. The proper exception message will be contained by this fix.