### PR TITLE
Add more invalid test cases for  parsing entitly declaration

### DIFF
--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -30,7 +30,7 @@ module REXMLTests
       class TestName < self
         def test_prohibited_character
           exception = assert_raise(REXML::ParseException) do
-            REXML::Document.new('<!DOCTYPE root [<!ENTITY invalid&name "valid-entity-value">]>')
+            REXML::Document.new("<!DOCTYPE root [<!ENTITY invalid&name \"valid-entity-value\">]>")
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -48,7 +48,7 @@ Last 80 unconsumed characters:
         class TestEntityValue < self
           def test_no_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value>]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value>]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -61,7 +61,7 @@ Last 80 unconsumed characters:
 
           def test_prohibited_character
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &">]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name \"% &\">]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -74,7 +74,7 @@ Last 80 unconsumed characters:
 
           def test_mixed_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "invalid-entity-value\'>]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name \"invalid-entity-value'>]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -92,7 +92,7 @@ Last 80 unconsumed characters:
           class TestSystemLiteral < self
             def test_no_quote_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -105,7 +105,7 @@ Last 80 unconsumed characters:
 
             def test_no_quote_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -118,7 +118,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM \'invalid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name SYSTEM 'invalid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -131,7 +131,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "invalid-system-literal\'>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"valid-pubid-literal\" \"invalid-system-literal'>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -144,7 +144,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name SYSTEM>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -157,7 +157,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"valid-pubid-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -174,7 +174,7 @@ Last 80 unconsumed characters:
           class TestPublicIDLiteral < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -201,7 +201,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "invalid-pubid-literal\' "valid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"invalid-pubid-literal' \"valid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -214,7 +214,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -232,7 +232,7 @@ Last 80 unconsumed characters:
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NameChar
           def test_prohibited_character
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" NDATA invalid&name>]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" NDATA invalid&name>]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -246,7 +246,7 @@ Last 80 unconsumed characters:
 
         def test_entity_value_and_notation_data_declaration
           exception = assert_raise(REXML::ParseException) do
-            REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+            REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>")
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -260,7 +260,7 @@ Last 80 unconsumed characters:
 
       def test_no_space
         exception = assert_raise(REXML::ParseException) do
-          REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-namePUBLIC"valid-pubid-literal""valid-system-literal"NDATAvalid-name>]>')
+          REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-namePUBLIC\"valid-pubid-literal\"\"valid-system-literal\"NDATAvalid-name>]>")
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -278,7 +278,7 @@ Last 80 unconsumed characters:
       class TestName < self
         def test_prohibited_character
           exception = assert_raise(REXML::ParseException) do
-            REXML::Document.new('<!DOCTYPE root [<!ENTITY % invalid&name "valid-entity-value">]>')
+            REXML::Document.new("<!DOCTYPE root [<!ENTITY % invalid&name \"valid-entity-value\">]>")
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -296,7 +296,7 @@ Last 80 unconsumed characters:
         class TestEntityValue < self
           def test_no_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value>]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value>]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -309,7 +309,7 @@ Last 80 unconsumed characters:
 
           def test_prohibited_character
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &">]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name \"% &\">]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -322,7 +322,7 @@ Last 80 unconsumed characters:
 
           def test_mixed_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name \'invalid-entity-value">]>')
+              REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name 'invalid-entity-value\">]>")
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -340,7 +340,7 @@ Last 80 unconsumed characters:
           class TestSystemLiteral < self
             def test_no_quote_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -353,7 +353,7 @@ Last 80 unconsumed characters:
 
             def test_no_quote_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -366,7 +366,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM "invalid-system-literal\'>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name SYSTEM \"invalid-system-literal'>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -379,7 +379,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" \'invalid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"valid-pubid-literal\" 'invalid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -392,7 +392,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name SYSTEM>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -405,7 +405,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"valid-pubid-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -422,7 +422,7 @@ Last 80 unconsumed characters:
           class TestPublicIDLiteral < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -449,7 +449,7 @@ Last 80 unconsumed characters:
 
             def test_mixed_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \'invalid-pubid-literal" "valid-system-literal">]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC 'invalid-pubid-literal\" \"valid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -462,7 +462,7 @@ Last 80 unconsumed characters:
 
             def test_no_literal
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC>]>')
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC>]>")
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -477,7 +477,7 @@ Last 80 unconsumed characters:
 
         def test_entity_value_and_notation_data_declaration
           exception = assert_raise(REXML::ParseException) do
-            REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+            REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>")
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
@@ -491,7 +491,7 @@ Last 80 unconsumed characters:
 
       def test_no_space
         exception = assert_raise(REXML::ParseException) do
-          REXML::Document.new('<!DOCTYPE root [<!ENTITY %valid-nameSYSTEM"valid-system-literal">]>')
+          REXML::Document.new("<!DOCTYPE root [<!ENTITY %valid-nameSYSTEM\"valid-system-literal\">]>")
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -141,6 +141,32 @@ Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" \"invalid-system-literal'>]>
               DETAIL
             end
+
+            def test_no_literal_in_system
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 45
+Last 80 unconsumed characters:
+ valid-name SYSTEM>]>
+              DETAIL
+            end
+
+            def test_no_literal_in_public
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 67
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"valid-pubid-literal\">]>
+              DETAIL
+            end
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
@@ -183,6 +209,19 @@ Line: 1
 Position: 92
 Last 80 unconsumed characters:
  valid-name PUBLIC \"invalid-pubid-literal' \"valid-system-literal\">]>
+              DETAIL
+            end
+
+            def test_no_literal
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 45
+Last 80 unconsumed characters:
+ valid-name PUBLIC>]>
               DETAIL
             end
           end
@@ -350,6 +389,32 @@ Last 80 unconsumed characters:
  % valid-name PUBLIC \"valid-pubid-literal\" 'invalid-system-literal\">]>
               DETAIL
             end
+
+            def test_no_literal_in_system
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 47
+Last 80 unconsumed characters:
+ % valid-name SYSTEM>]>
+              DETAIL
+            end
+
+            def test_no_literal_in_public
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 69
+Last 80 unconsumed characters:
+ % valid-name PUBLIC \"valid-pubid-literal\">]>
+              DETAIL
+            end
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
@@ -392,6 +457,19 @@ Line: 1
 Position: 94
 Last 80 unconsumed characters:
  % valid-name PUBLIC 'invalid-pubid-literal\" \"valid-system-literal\">]>
+              DETAIL
+            end
+
+            def test_no_literal
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 47
+Last 80 unconsumed characters:
+ % valid-name PUBLIC>]>
               DETAIL
             end
           end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -32,27 +32,27 @@ module REXMLTests
         class TestEntityValue < self
           def test_no_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value > ]>')
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value>]>')
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 61
+Position: 59
 Last 80 unconsumed characters:
- valid-name invalid-entity-value > ]>
+ valid-name invalid-entity-value>]>
             DETAIL
           end
 
           def test_invalid_entity_value
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &" > ]>')
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &">]>')
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 46
+Position: 44
 Last 80 unconsumed characters:
- valid-name \"% &\" > ]>
+ valid-name \"% &\">]>
             DETAIL
           end
 
@@ -62,27 +62,27 @@ Last 80 unconsumed characters:
             class TestSystemLiteral < self
               def test_no_quote_in_system
                 exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal > ]>')
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal>]>')
                 end
                 assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 70
+Position: 68
 Last 80 unconsumed characters:
- valid-name SYSTEM invalid-system-literal > ]>
+ valid-name SYSTEM invalid-system-literal>]>
                 DETAIL
               end
 
               def test_no_quote_in_public
                 exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
                 end
                 assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 92
+Position: 90
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal > ]>
+ valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
                 DETAIL
               end
             end
@@ -92,28 +92,28 @@ Last 80 unconsumed characters:
             class TestPubidLiteral < self
               def test_no_quote
                 exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
                 end
                 assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 92
+Position: 90
 Last 80 unconsumed characters:
- valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\" > ]>
+ valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>
                 DETAIL
               end
 
               def test_invalid_pubid_char
                 exception = assert_raise(REXML::ParseException) do
                   # U+3042 HIRAGANA LETTER A
-                  REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
+                  REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")
                 end
                 assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
 Malformed entity declaration
 Line: 1
-Position: 76
+Position: 74
 Last 80 unconsumed characters:
- valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>
+ valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
                 DETAIL
               end
             end
@@ -123,12 +123,12 @@ Last 80 unconsumed characters:
           class TestNDataDeclaration < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value> ]>')
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value>]>')
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 123
+Position: 122
 Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" invalid-ndata val
               DETAIL
@@ -146,27 +146,27 @@ Last 80 unconsumed characters:
         class TestEntityValue < self
           def test_no_quote
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value > ]>')
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value>]>')
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 63
+Position: 61
 Last 80 unconsumed characters:
- % valid-name invalid-entity-value > ]>
+ % valid-name invalid-entity-value>]>
             DETAIL
           end
 
           def test_invalid_entity_value
             exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &" > ]>')
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &">]>')
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 48
+Position: 46
 Last 80 unconsumed characters:
- % valid-name \"% &\" > ]>
+ % valid-name \"% &\">]>
             DETAIL
           end
         end
@@ -177,27 +177,27 @@ Last 80 unconsumed characters:
           class TestSystemLiteral < self
             def test_no_quote_in_system
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal > ]>')
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal>]>')
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 72
+Position: 70
 Last 80 unconsumed characters:
- % valid-name SYSTEM invalid-system-literal > ]>
+ % valid-name SYSTEM invalid-system-literal>]>
               DETAIL
             end
 
             def test_no_quote_in_public
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 94
+Position: 92
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal > ]>
+ % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
               DETAIL
             end
           end
@@ -207,28 +207,28 @@ Last 80 unconsumed characters:
           class TestPubidLiteral < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 94
+Position: 92
 Last 80 unconsumed characters:
- % valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\" > ]>
+ % valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>
               DETAIL
             end
 
             def test_invalid_pubid_char
               exception = assert_raise(REXML::ParseException) do
                 # U+3042 HIRAGANA LETTER A
-                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")
               end
               assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
 Malformed entity declaration
 Line: 1
-Position: 78
+Position: 76
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>
+ % valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
               DETAIL
             end
           end
@@ -237,14 +237,14 @@ Last 80 unconsumed characters:
 
       def test_unnecessary_ndata_declaration
         exception = assert_raise(REXML::ParseException) do
-          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" "NDATA" valid-ndata-value > ]>')
+          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" "NDATA" valid-ndata-value>]>')
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 89
+Position: 87
 Last 80 unconsumed characters:
- % valid-name \"valid-entity-value\" \"NDATA\" valid-ndata-value > ]>
+ % valid-name \"valid-entity-value\" \"NDATA\" valid-ndata-value>]>
         DETAIL
       end
     end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -71,19 +71,6 @@ Last 80 unconsumed characters:
  valid-name \"% &\">]>
             DETAIL
           end
-
-          def test_unnecessary_ndata_declaration
-            exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
-            end
-            assert_equal(<<-DETAIL.chomp, exception.to_s)
-Malformed entity declaration
-Line: 1
-Position: 83
-Last 80 unconsumed characters:
- valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
-        DETAIL
-          end
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
@@ -164,6 +151,19 @@ Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" NDATA invalid&nam
             DETAIL
           end
+        end
+
+        def test_entity_value_and_notation_data_declaration
+          exception = assert_raise(REXML::ParseException) do
+            REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 83
+Last 80 unconsumed characters:
+ valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
+        DETAIL
         end
       end
     end
@@ -280,7 +280,7 @@ Last 80 unconsumed characters:
           end
         end
 
-        def test_unnecessary_ndata_declaration
+        def test_entity_value_and_notation_data_declaration
           exception = assert_raise(REXML::ParseException) do
             REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
           end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -215,19 +215,6 @@ Last 80 unconsumed characters:
  % valid-name \"% &\">]>
             DETAIL
           end
-
-          def test_unnecessary_ndata_declaration
-            exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
-            end
-            assert_equal(<<-DETAIL.chomp, exception.to_s)
-Malformed entity declaration
-Line: 1
-Position: 85
-Last 80 unconsumed characters:
- % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
-            DETAIL
-          end
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -218,6 +218,19 @@ Last 80 unconsumed characters:
         DETAIL
         end
       end
+
+      def test_no_space
+        exception = assert_raise(REXML::ParseException) do
+          REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-namePUBLIC"valid-pubid-literal""valid-system-literal"NDATAvalid-name>]>')
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 102
+Last 80 unconsumed characters:
+ valid-namePUBLIC\"valid-pubid-literal\"\"valid-system-literal\"NDATAvalid-name>]>
+        DETAIL
+      end
     end
 
     # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
@@ -396,6 +409,19 @@ Last 80 unconsumed characters:
  % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
         DETAIL
         end
+      end
+
+      def test_no_space
+        exception = assert_raise(REXML::ParseException) do
+          REXML::Document.new('<!DOCTYPE root [<!ENTITY %valid-nameSYSTEM"valid-system-literal">]>')
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 67
+Last 80 unconsumed characters:
+ %valid-nameSYSTEM\"valid-system-literal\">]>
+        DETAIL
       end
     end
 

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -23,6 +23,239 @@ module REXMLTests
     end
 
     public
+
+    class TestGeneralEntityDeclaration < self
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-GEDecl
+      class TestEntityDefinition < self
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityDef
+        class TestEntityValue < self
+          def test_no_quote
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value > ]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 61
+Last 80 unconsumed characters:
+ valid-name invalid-entity-value > ]>
+            DETAIL
+          end
+
+          def test_invalid_entity_value
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &" > ]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 46
+Last 80 unconsumed characters:
+ valid-name \"% &\" > ]>
+            DETAIL
+          end
+
+          class TestExternalId < self
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
+            class TestSystemLiteral < self
+              def test_no_quote_in_system
+                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
+                exception = assert_raise(REXML::ParseException) do
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal > ]>')
+                end
+                assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 70
+Last 80 unconsumed characters:
+ valid-name SYSTEM invalid-system-literal > ]>
+                DETAIL
+              end
+
+              def test_no_quote_in_public
+                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
+                exception = assert_raise(REXML::ParseException) do
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
+                end
+                assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 92
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal > ]>
+                DETAIL
+              end
+            end
+
+            class TestPubidLiteral < self
+              def test_no_quote
+                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
+                exception = assert_raise(REXML::ParseException) do
+                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
+                end
+                assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 92
+Last 80 unconsumed characters:
+ valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\" > ]>
+                DETAIL
+              end
+
+              def test_invalid_pubid_char
+                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
+                exception = assert_raise(REXML::ParseException) do
+                  # U+3042 HIRAGANA LETTER A
+                  REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
+                end
+                assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
+Malformed entity declaration
+Line: 1
+Position: 76
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>
+                DETAIL
+              end
+            end
+          end
+
+          class TestNDataDeclaration < self
+            def test_no_quote
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value> ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 123
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" invalid-ndata val
+              DETAIL
+            end
+          end
+        end
+      end
+    end
+
+    class TestParsedEntityDeclaration < self
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
+      class ParsedEntityDefinition < self
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
+        class TestEntityValue < self
+          class TestEntityValue < self
+            def test_no_quote
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value > ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 63
+Last 80 unconsumed characters:
+ % valid-name invalid-entity-value > ]>
+              DETAIL
+            end
+
+            def test_invalid_entity_value
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &" > ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 48
+Last 80 unconsumed characters:
+ % valid-name \"% &\" > ]>
+              DETAIL
+            end
+          end
+        end
+
+        class TestExternalId < self
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
+          class TestSystemLiteral < self
+            def test_no_quote_in_system
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal > ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 72
+Last 80 unconsumed characters:
+ % valid-name SYSTEM invalid-system-literal > ]>
+              DETAIL
+            end
+
+            def test_no_quote_in_public
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 94
+Last 80 unconsumed characters:
+ % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal > ]>
+              DETAIL
+            end
+          end
+
+          class TestPubidLiteral < self
+            def test_no_quote
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 94
+Last 80 unconsumed characters:
+ % valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\" > ]>
+              DETAIL
+            end
+
+            def test_invalid_pubid_char
+              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
+              exception = assert_raise(REXML::ParseException) do
+                # U+3042 HIRAGANA LETTER A
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
+              end
+              assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
+Malformed entity declaration
+Line: 1
+Position: 78
+Last 80 unconsumed characters:
+ % valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>
+              DETAIL
+            end
+          end
+        end
+      end
+
+      def test_unnecessary_ndata_declaration
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
+        exception = assert_raise(REXML::ParseException) do
+          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" "NDATA" valid-ndata-value > ]>')
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 89
+Last 80 unconsumed characters:
+ % valid-name \"valid-entity-value\" \"NDATA\" valid-ndata-value > ]>
+        DETAIL
+      end
+    end
+
     def test_empty
       exception = assert_raise(REXML::ParseException) do
         parse(<<-INTERNAL_SUBSET)

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -26,6 +26,22 @@ module REXMLTests
 
     # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-GEDecl
     class TestGeneralEntityDeclaration < self
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Name
+      class TestName < self
+        def test_prohibited_character
+          exception = assert_raise(REXML::ParseException) do
+            REXML::Document.new('<!DOCTYPE root [<!ENTITY invalid&name "valid-entity-value">]>')
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 61
+Last 80 unconsumed characters:
+ invalid&name \"valid-entity-value\">]>
+          DETAIL
+        end
+      end
+
       # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityDef
       class TestEntityDefinition < self
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
@@ -121,16 +137,17 @@ Last 80 unconsumed characters:
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
           class TestNotationDataDeclaration < self
-            def test_no_quote
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NameChar
+            def test_prohibited_character
               exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value>]>')
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" NDATA invalid&name>]>')
               end
               assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 122
+Position: 109
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" invalid-ndata val
+ valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" NDATA invalid&nam
               DETAIL
             end
           end
@@ -142,6 +159,22 @@ Last 80 unconsumed characters:
     class TestParsedEntityDeclaration < self
       # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
       class TestParsedEntityDefinition < self
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Name
+        class TestName < self
+          def test_prohibited_character
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % invalid&name "valid-entity-value">]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 63
+Last 80 unconsumed characters:
+ % invalid&name \"valid-entity-value\">]>
+          DETAIL
+          end
+        end
+
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
         class TestEntityValue < self
           def test_no_quote

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -159,7 +159,7 @@ Last 80 unconsumed characters:
               DETAIL
             end
 
-            def test_invalid_pubid_char
+            def test_prohibited_pubid_character
               exception = assert_raise(REXML::ParseException) do
                 # U+3042 HIRAGANA LETTER A
                 REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -24,13 +24,13 @@ module REXMLTests
 
     public
 
+    # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-GEDecl
     class TestGeneralEntityDeclaration < self
-      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-GEDecl
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityDef
       class TestEntityDefinition < self
-        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityDef
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
         class TestEntityValue < self
           def test_no_quote
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name invalid-entity-value > ]>')
             end
@@ -44,7 +44,6 @@ Last 80 unconsumed characters:
           end
 
           def test_invalid_entity_value
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &" > ]>')
             end
@@ -57,11 +56,11 @@ Last 80 unconsumed characters:
             DETAIL
           end
 
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
           class TestExternalId < self
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
             class TestSystemLiteral < self
               def test_no_quote_in_system
-                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
                 exception = assert_raise(REXML::ParseException) do
                   REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal > ]>')
                 end
@@ -75,7 +74,6 @@ Last 80 unconsumed characters:
               end
 
               def test_no_quote_in_public
-                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
                 exception = assert_raise(REXML::ParseException) do
                   REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
                 end
@@ -89,9 +87,10 @@ Last 80 unconsumed characters:
               end
             end
 
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
             class TestPubidLiteral < self
               def test_no_quote
-                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
                 exception = assert_raise(REXML::ParseException) do
                   REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
                 end
@@ -105,7 +104,6 @@ Last 80 unconsumed characters:
               end
 
               def test_invalid_pubid_char
-                # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
                 exception = assert_raise(REXML::ParseException) do
                   # U+3042 HIRAGANA LETTER A
                   REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
@@ -121,9 +119,9 @@ Last 80 unconsumed characters:
             end
           end
 
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
           class TestNDataDeclaration < self
             def test_no_quote
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value> ]>')
               end
@@ -140,13 +138,13 @@ Last 80 unconsumed characters:
       end
     end
 
+    # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
     class TestParsedEntityDeclaration < self
-      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
       class ParsedEntityDefinition < self
-        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
         class TestEntityValue < self
           def test_no_quote
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value > ]>')
             end
@@ -160,7 +158,6 @@ Last 80 unconsumed characters:
           end
 
           def test_invalid_entity_value
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &" > ]>')
             end
@@ -174,11 +171,11 @@ Last 80 unconsumed characters:
           end
         end
 
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
         class TestExternalId < self
-          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
           class TestSystemLiteral < self
             def test_no_quote_in_system
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM invalid-system-literal > ]>')
               end
@@ -192,7 +189,6 @@ Last 80 unconsumed characters:
             end
 
             def test_no_quote_in_public
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal > ]>')
               end
@@ -206,9 +202,10 @@ Last 80 unconsumed characters:
             end
           end
 
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
           class TestPubidLiteral < self
             def test_no_quote
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal" > ]>')
               end
@@ -222,7 +219,6 @@ Last 80 unconsumed characters:
             end
 
             def test_invalid_pubid_char
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
               exception = assert_raise(REXML::ParseException) do
                 # U+3042 HIRAGANA LETTER A
                 REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"\u3042\" \"valid-system-literal\" > ]>")
@@ -240,7 +236,6 @@ Last 80 unconsumed characters:
       end
 
       def test_unnecessary_ndata_declaration
-        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
         exception = assert_raise(REXML::ParseException) do
           REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" "NDATA" valid-ndata-value > ]>')
         end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -71,85 +71,85 @@ Last 80 unconsumed characters:
  valid-name \"% &\">]>
             DETAIL
           end
+        end
 
-          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
-          class TestExternalID < self
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
-            class TestSystemLiteral < self
-              def test_no_quote_in_system
-                exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal>]>')
-                end
-                assert_equal(<<-DETAIL.chomp, exception.to_s)
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
+        class TestExternalID < self
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
+          class TestSystemLiteral < self
+            def test_no_quote_in_system
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM invalid-system-literal>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 68
 Last 80 unconsumed characters:
  valid-name SYSTEM invalid-system-literal>]>
-                DETAIL
-              end
+              DETAIL
+            end
 
-              def test_no_quote_in_public
-                exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
-                end
-                assert_equal(<<-DETAIL.chomp, exception.to_s)
+            def test_no_quote_in_public
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 90
 Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
-                DETAIL
-              end
+              DETAIL
             end
+          end
 
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
-            class TestPublicIDLiteral < self
-              def test_no_quote
-                exception = assert_raise(REXML::ParseException) do
-                  REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
-                end
-                assert_equal(<<-DETAIL.chomp, exception.to_s)
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
+          class TestPublicIDLiteral < self
+            def test_no_quote
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 90
 Last 80 unconsumed characters:
  valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>
-                DETAIL
-              end
+              DETAIL
+            end
 
-              def test_invalid_pubid_char
-                exception = assert_raise(REXML::ParseException) do
-                  # U+3042 HIRAGANA LETTER A
-                  REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")
-                end
-                assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
+            def test_invalid_pubid_char
+              exception = assert_raise(REXML::ParseException) do
+                # U+3042 HIRAGANA LETTER A
+                REXML::Document.new("<!DOCTYPE root [<!ENTITY valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")
+              end
+              assert_equal(<<-DETAIL.force_encoding('utf-8').chomp, exception.to_s.force_encoding('utf-8'))
 Malformed entity declaration
 Line: 1
 Position: 74
 Last 80 unconsumed characters:
  valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
-                DETAIL
-              end
+              DETAIL
             end
           end
+        end
 
-          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
-          class TestNotationDataDeclaration < self
-            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NameChar
-            def test_prohibited_character
-              exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" NDATA invalid&name>]>')
-              end
-              assert_equal(<<-DETAIL.chomp, exception.to_s)
+        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
+        class TestNotationDataDeclaration < self
+          # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NameChar
+          def test_prohibited_character
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" NDATA invalid&name>]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 109
 Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" NDATA invalid&nam
-              DETAIL
-            end
+            DETAIL
           end
         end
       end
@@ -157,24 +157,24 @@ Last 80 unconsumed characters:
 
     # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
     class TestParsedEntityDeclaration < self
-      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
-      class TestParsedEntityDefinition < self
-        # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Name
-        class TestName < self
-          def test_prohibited_character
-            exception = assert_raise(REXML::ParseException) do
-              REXML::Document.new('<!DOCTYPE root [<!ENTITY % invalid&name "valid-entity-value">]>')
-            end
-            assert_equal(<<-DETAIL.chomp, exception.to_s)
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Name
+      class TestName < self
+        def test_prohibited_character
+          exception = assert_raise(REXML::ParseException) do
+            REXML::Document.new('<!DOCTYPE root [<!ENTITY % invalid&name "valid-entity-value">]>')
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 63
 Last 80 unconsumed characters:
  % invalid&name \"valid-entity-value\">]>
           DETAIL
-          end
         end
+      end
 
+      # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
+      class TestParsedEntityDefinition < self
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
         class TestEntityValue < self
           def test_no_quote
@@ -266,19 +266,19 @@ Last 80 unconsumed characters:
             end
           end
         end
-      end
 
-      def test_unnecessary_ndata_declaration
-        exception = assert_raise(REXML::ParseException) do
-          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
-        end
-        assert_equal(<<-DETAIL.chomp, exception.to_s)
+        def test_unnecessary_ndata_declaration
+          exception = assert_raise(REXML::ParseException) do
+            REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 85
 Last 80 unconsumed characters:
  % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
         DETAIL
+        end
       end
     end
 

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -71,6 +71,19 @@ Last 80 unconsumed characters:
  valid-name \"% &\">]>
             DETAIL
           end
+
+          def test_mixed_quote
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "invalid-entity-value\'>]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 61
+Last 80 unconsumed characters:
+ valid-name \"invalid-entity-value'>]>
+            DETAIL
+          end
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
@@ -102,6 +115,32 @@ Last 80 unconsumed characters:
  valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
               DETAIL
             end
+
+            def test_mixed_quote_in_system
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name SYSTEM \'invalid-system-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 70
+Last 80 unconsumed characters:
+ valid-name SYSTEM 'invalid-system-literal\">]>
+              DETAIL
+            end
+
+            def test_mixed_quote_in_public
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "invalid-system-literal\'>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 92
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"valid-pubid-literal\" \"invalid-system-literal'>]>
+              DETAIL
+            end
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
@@ -131,6 +170,19 @@ Line: 1
 Position: 74
 Last 80 unconsumed characters:
  valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
+              DETAIL
+            end
+
+            def test_mixed_quote
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "invalid-pubid-literal\' "valid-system-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 92
+Last 80 unconsumed characters:
+ valid-name PUBLIC \"invalid-pubid-literal' \"valid-system-literal\">]>
               DETAIL
             end
           end
@@ -215,6 +267,19 @@ Last 80 unconsumed characters:
  % valid-name \"% &\">]>
             DETAIL
           end
+
+          def test_mixed_quote
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name \'invalid-entity-value">]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 63
+Last 80 unconsumed characters:
+ % valid-name 'invalid-entity-value\">]>
+            DETAIL
+          end
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
@@ -246,6 +311,32 @@ Last 80 unconsumed characters:
  % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
               DETAIL
             end
+
+            def test_mixed_quote_in_system
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name SYSTEM "invalid-system-literal\'>]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 72
+Last 80 unconsumed characters:
+ % valid-name SYSTEM \"invalid-system-literal'>]>
+              DETAIL
+            end
+
+            def test_mixed_quote_in_public
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC "valid-pubid-literal" \'invalid-system-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 94
+Last 80 unconsumed characters:
+ % valid-name PUBLIC \"valid-pubid-literal\" 'invalid-system-literal\">]>
+              DETAIL
+            end
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
@@ -275,6 +366,19 @@ Line: 1
 Position: 76
 Last 80 unconsumed characters:
  % valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
+              DETAIL
+            end
+
+            def test_mixed_quote
+              exception = assert_raise(REXML::ParseException) do
+                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \'invalid-pubid-literal" "valid-system-literal">]>')
+              end
+              assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 94
+Last 80 unconsumed characters:
+ % valid-name PUBLIC 'invalid-pubid-literal\" \"valid-system-literal\">]>
               DETAIL
             end
           end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -71,6 +71,19 @@ Last 80 unconsumed characters:
  valid-name \"% &\">]>
             DETAIL
           end
+
+          def test_unnecessary_ndata_declaration
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 83
+Last 80 unconsumed characters:
+ valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
+        DETAIL
+          end
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
@@ -200,6 +213,19 @@ Line: 1
 Position: 46
 Last 80 unconsumed characters:
  % valid-name \"% &\">]>
+            DETAIL
+          end
+
+          def test_unnecessary_ndata_declaration
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed entity declaration
+Line: 1
+Position: 85
+Last 80 unconsumed characters:
+ % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
             DETAIL
           end
         end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -43,7 +43,7 @@ Last 80 unconsumed characters:
             DETAIL
           end
 
-          def test_invalid_entity_value
+          def test_prohibited_character
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name "% &">]>')
             end
@@ -157,7 +157,7 @@ Last 80 unconsumed characters:
             DETAIL
           end
 
-          def test_invalid_entity_value
+          def test_prohibited_character
             exception = assert_raise(REXML::ParseException) do
               REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &">]>')
             end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -237,14 +237,14 @@ Last 80 unconsumed characters:
 
       def test_unnecessary_ndata_declaration
         exception = assert_raise(REXML::ParseException) do
-          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" "NDATA" valid-ndata-value>]>')
+          REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "valid-entity-value" NDATA valid-ndata-value>]>')
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
-Position: 87
+Position: 85
 Last 80 unconsumed characters:
- % valid-name \"valid-entity-value\" \"NDATA\" valid-ndata-value>]>
+ % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
         DETAIL
       end
     end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -145,34 +145,32 @@ Last 80 unconsumed characters:
       class ParsedEntityDefinition < self
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
         class TestEntityValue < self
-          class TestEntityValue < self
-            def test_no_quote
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
-              exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value > ]>')
-              end
-              assert_equal(<<-DETAIL.chomp, exception.to_s)
+          def test_no_quote
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name invalid-entity-value > ]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 63
 Last 80 unconsumed characters:
  % valid-name invalid-entity-value > ]>
-              DETAIL
-            end
+            DETAIL
+          end
 
-            def test_invalid_entity_value
-              # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
-              exception = assert_raise(REXML::ParseException) do
-                REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &" > ]>')
-              end
-              assert_equal(<<-DETAIL.chomp, exception.to_s)
+          def test_invalid_entity_value
+            # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
+            exception = assert_raise(REXML::ParseException) do
+              REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name "% &" > ]>')
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed entity declaration
 Line: 1
 Position: 48
 Last 80 unconsumed characters:
  % valid-name \"% &\" > ]>
-              DETAIL
-            end
+            DETAIL
           end
         end
 

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -57,7 +57,7 @@ Last 80 unconsumed characters:
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
-          class TestExternalId < self
+          class TestExternalID < self
             # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
             class TestSystemLiteral < self
               def test_no_quote_in_system
@@ -89,7 +89,7 @@ Last 80 unconsumed characters:
 
             # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
             # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
-            class TestPubidLiteral < self
+            class TestPublicIDLiteral < self
               def test_no_quote
                 exception = assert_raise(REXML::ParseException) do
                   REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')
@@ -120,7 +120,7 @@ Last 80 unconsumed characters:
           end
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-NDataDecl
-          class TestNDataDeclaration < self
+          class TestNotationDataDeclaration < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" invalid-ndata valid-ndata-value>]>')
@@ -141,7 +141,7 @@ Last 80 unconsumed characters:
     # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDecl
     class TestParsedEntityDeclaration < self
       # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PEDef
-      class ParsedEntityDefinition < self
+      class TestParsedEntityDefinition < self
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-EntityValue
         class TestEntityValue < self
           def test_no_quote
@@ -172,7 +172,7 @@ Last 80 unconsumed characters:
         end
 
         # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-ExternalID
-        class TestExternalId < self
+        class TestExternalID < self
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-SystemLiteral
           class TestSystemLiteral < self
             def test_no_quote_in_system
@@ -204,7 +204,7 @@ Last 80 unconsumed characters:
 
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidLiteral
           # https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-PubidChar
-          class TestPubidLiteral < self
+          class TestPublicIDLiteral < self
             def test_no_quote
               exception = assert_raise(REXML::ParseException) do
                 REXML::Document.new('<!DOCTYPE root [<!ENTITY % valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>')

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -37,7 +37,7 @@ Malformed entity declaration
 Line: 1
 Position: 61
 Last 80 unconsumed characters:
- invalid&name \"valid-entity-value\">]>
+ invalid&name "valid-entity-value">]>
           DETAIL
         end
       end
@@ -68,7 +68,7 @@ Malformed entity declaration
 Line: 1
 Position: 44
 Last 80 unconsumed characters:
- valid-name \"% &\">]>
+ valid-name "% &">]>
             DETAIL
           end
 
@@ -81,7 +81,7 @@ Malformed entity declaration
 Line: 1
 Position: 61
 Last 80 unconsumed characters:
- valid-name \"invalid-entity-value'>]>
+ valid-name "invalid-entity-value'>]>
             DETAIL
           end
         end
@@ -112,7 +112,7 @@ Malformed entity declaration
 Line: 1
 Position: 90
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
+ valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>
               DETAIL
             end
 
@@ -125,7 +125,7 @@ Malformed entity declaration
 Line: 1
 Position: 70
 Last 80 unconsumed characters:
- valid-name SYSTEM 'invalid-system-literal\">]>
+ valid-name SYSTEM 'invalid-system-literal">]>
               DETAIL
             end
 
@@ -138,7 +138,7 @@ Malformed entity declaration
 Line: 1
 Position: 92
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\" \"invalid-system-literal'>]>
+ valid-name PUBLIC "valid-pubid-literal" "invalid-system-literal'>]>
               DETAIL
             end
 
@@ -164,7 +164,7 @@ Malformed entity declaration
 Line: 1
 Position: 67
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\">]>
+ valid-name PUBLIC "valid-pubid-literal">]>
               DETAIL
             end
           end
@@ -181,7 +181,7 @@ Malformed entity declaration
 Line: 1
 Position: 90
 Last 80 unconsumed characters:
- valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>
+ valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>
               DETAIL
             end
 
@@ -195,7 +195,7 @@ Malformed entity declaration
 Line: 1
 Position: 74
 Last 80 unconsumed characters:
- valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
+ valid-name PUBLIC "\u3042" "valid-system-literal">]>
               DETAIL
             end
 
@@ -208,7 +208,7 @@ Malformed entity declaration
 Line: 1
 Position: 92
 Last 80 unconsumed characters:
- valid-name PUBLIC \"invalid-pubid-literal' \"valid-system-literal\">]>
+ valid-name PUBLIC "invalid-pubid-literal' "valid-system-literal">]>
               DETAIL
             end
 
@@ -239,7 +239,7 @@ Malformed entity declaration
 Line: 1
 Position: 109
 Last 80 unconsumed characters:
- valid-name PUBLIC \"valid-pubid-literal\" \"valid-system-literal\" NDATA invalid&nam
+ valid-name PUBLIC "valid-pubid-literal" "valid-system-literal" NDATA invalid&nam
             DETAIL
           end
         end
@@ -253,7 +253,7 @@ Malformed entity declaration
 Line: 1
 Position: 83
 Last 80 unconsumed characters:
- valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
+ valid-name "valid-entity-value" NDATA valid-ndata-value>]>
         DETAIL
         end
       end
@@ -267,7 +267,7 @@ Malformed entity declaration
 Line: 1
 Position: 102
 Last 80 unconsumed characters:
- valid-namePUBLIC\"valid-pubid-literal\"\"valid-system-literal\"NDATAvalid-name>]>
+ valid-namePUBLIC"valid-pubid-literal""valid-system-literal"NDATAvalid-name>]>
         DETAIL
       end
     end
@@ -285,7 +285,7 @@ Malformed entity declaration
 Line: 1
 Position: 63
 Last 80 unconsumed characters:
- % invalid&name \"valid-entity-value\">]>
+ % invalid&name "valid-entity-value">]>
           DETAIL
         end
       end
@@ -316,7 +316,7 @@ Malformed entity declaration
 Line: 1
 Position: 46
 Last 80 unconsumed characters:
- % valid-name \"% &\">]>
+ % valid-name "% &">]>
             DETAIL
           end
 
@@ -329,7 +329,7 @@ Malformed entity declaration
 Line: 1
 Position: 63
 Last 80 unconsumed characters:
- % valid-name 'invalid-entity-value\">]>
+ % valid-name 'invalid-entity-value">]>
             DETAIL
           end
         end
@@ -360,7 +360,7 @@ Malformed entity declaration
 Line: 1
 Position: 92
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"valid-pubid-literal\" invalid-system-literal>]>
+ % valid-name PUBLIC "valid-pubid-literal" invalid-system-literal>]>
               DETAIL
             end
 
@@ -373,7 +373,7 @@ Malformed entity declaration
 Line: 1
 Position: 72
 Last 80 unconsumed characters:
- % valid-name SYSTEM \"invalid-system-literal'>]>
+ % valid-name SYSTEM "invalid-system-literal'>]>
               DETAIL
             end
 
@@ -386,7 +386,7 @@ Malformed entity declaration
 Line: 1
 Position: 94
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"valid-pubid-literal\" 'invalid-system-literal\">]>
+ % valid-name PUBLIC "valid-pubid-literal" 'invalid-system-literal">]>
               DETAIL
             end
 
@@ -412,7 +412,7 @@ Malformed entity declaration
 Line: 1
 Position: 69
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"valid-pubid-literal\">]>
+ % valid-name PUBLIC "valid-pubid-literal">]>
               DETAIL
             end
           end
@@ -429,7 +429,7 @@ Malformed entity declaration
 Line: 1
 Position: 92
 Last 80 unconsumed characters:
- % valid-name PUBLIC invalid-pubid-literal \"valid-system-literal\">]>
+ % valid-name PUBLIC invalid-pubid-literal "valid-system-literal">]>
               DETAIL
             end
 
@@ -443,7 +443,7 @@ Malformed entity declaration
 Line: 1
 Position: 76
 Last 80 unconsumed characters:
- % valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>
+ % valid-name PUBLIC "\u3042" "valid-system-literal">]>
               DETAIL
             end
 
@@ -456,7 +456,7 @@ Malformed entity declaration
 Line: 1
 Position: 94
 Last 80 unconsumed characters:
- % valid-name PUBLIC 'invalid-pubid-literal\" \"valid-system-literal\">]>
+ % valid-name PUBLIC 'invalid-pubid-literal" "valid-system-literal">]>
               DETAIL
             end
 
@@ -484,7 +484,7 @@ Malformed entity declaration
 Line: 1
 Position: 85
 Last 80 unconsumed characters:
- % valid-name \"valid-entity-value\" NDATA valid-ndata-value>]>
+ % valid-name "valid-entity-value" NDATA valid-ndata-value>]>
         DETAIL
         end
       end
@@ -498,7 +498,7 @@ Malformed entity declaration
 Line: 1
 Position: 67
 Last 80 unconsumed characters:
- %valid-nameSYSTEM\"valid-system-literal\">]>
+ %valid-nameSYSTEM"valid-system-literal">]>
         DETAIL
       end
     end

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -433,7 +433,7 @@ Last 80 unconsumed characters:
               DETAIL
             end
 
-            def test_invalid_pubid_char
+            def test_prohibited_pubid_character
               exception = assert_raise(REXML::ParseException) do
                 # U+3042 HIRAGANA LETTER A
                 REXML::Document.new("<!DOCTYPE root [<!ENTITY % valid-name PUBLIC \"\u3042\" \"valid-system-literal\">]>")


### PR DESCRIPTION
This patch will add the test cases to verify that it raises an exception properly when parsing malformed entity declaration.