### PR TITLE
Add missing rexml/security require in rexml/parsers/baseparser.rb

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative '../parseexception'
 require_relative '../undefinednamespaceexception'
+require_relative '../security'
 require_relative '../source'
 require 'set'
 require "strscan"


### PR DESCRIPTION
`REXML::Parser::BaseParser` uses `REXML::Security` since #187. But `rexml/parsers/baseparser.rb` doesn't require `rexml/security` explicitly.

This doesn't cause a problem in normal usages because `require "rexml"` requires `rexml/security` implicitly. If an user requires specific parser such as `rexml/parsers/streamparser` explicitly, this causes a problem.

We should require `rexml/security` explicitly in `rexml/parsers/baseparser.rb` explicitly because `REXML::Parser::BaseParser` uses `REXML::Security`.

## How to reproduce

When `lib/rexml/parsers/baseparser.rb` is required directly, the `REXML::Security` module is not required. It causes the following error:

```ruby
require "rexml/parsers/streamparser"
require "rexml/streamlistener"

class Listener
  include REXML::StreamListener
end

REXML::Parsers::StreamParser.new("<root>&gt;</root>", Listener.new).parse
```

```console
$ ruby test.rb
lib/rexml/parsers/baseparser.rb:558:in 'block in REXML::Parsers::BaseParser#unnormalize': uninitialized constant REXML::Parsers::BaseParser::Security (NameError)

                if sum > Security.entity_expansion_text_limit
                         ^^^^^^^^
Did you mean?  SecurityError
	from <internal:array>:54:in 'Array#each'
	from rexml/parsers/baseparser.rb:551:in 'REXML::Parsers::BaseParser#unnormalize'
	from rexml/parsers/streamparser.rb:39:in 'REXML::Parsers::StreamParser#parse'
	from test.rb:8:in '<main>'
```
