### PR TITLE
Add unit test for ReDoS vulnerability (CVE-2024-41123)

### DIFF
--- a/test/parse/test_processing_instruction.rb
+++ b/test/parse/test_processing_instruction.rb
@@ -123,5 +123,15 @@ Last 80 unconsumed characters:
         REXML::Document.new("<?name" + "\t" * n + "version=\"1.0\" > ?>")
       end
     end
+   
+    def test_linear_performance_tab_gt
+      seq = [10000, 50000, 100000, 150000, 200000]
+      assert_linear_performance(seq, rehearsal: 10) do |n|
+        _n = n / 3
+        REXML::Document.new("<?" + "0" * _n + "\t" * _n + ">" * _n)
+        rescue REXML::ParseException
+          # Ignored
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a unit test (`test_linear_performance_tab_gt`) to ensure the performance remains linear when processing specially crafted inputs that could previously exploit the ReDoS vulnerability.