### PR TITLE
Fix RuntimeError in `REXML::Parsers::BaseParser` for valid feeds

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -505,14 +505,13 @@ module REXML
       private :pull_event
 
       def entity( reference, entities )
-        value = nil
-        value = entities[ reference ] if entities
-        if value
-          record_entity_expansion
-          return unnormalize( value, entities )
-        end
+        return unless entities
 
-        nil
+        value = entities[ reference ]
+        return if value.nil?
+
+        record_entity_expansion
+        unnormalize( value, entities )
       end
 
       # Escapes all possible entities

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -505,15 +505,13 @@ module REXML
       private :pull_event
 
       def entity( reference, entities )
-        value = nil
         value = entities[ reference ] if entities
         if value
           record_entity_expansion
-        else
-          value = DEFAULT_ENTITIES[ reference ]
-          value = value[2] if value
+          return unnormalize( value, entities ) if value
         end
-        unnormalize( value, entities ) if value
+
+        nil
       end
 
       # Escapes all possible entities

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -505,10 +505,11 @@ module REXML
       private :pull_event
 
       def entity( reference, entities )
+        value = nil
         value = entities[ reference ] if entities
         if value
           record_entity_expansion
-          return unnormalize( value, entities ) if value
+          return unnormalize( value, entities )
         end
 
         nil

--- a/test/test_pullparser.rb
+++ b/test/test_pullparser.rb
@@ -252,6 +252,36 @@ module REXMLTests
           end
         end
 
+        def test_with_only_default_entities
+          member_value = "&lt;p&gt;#{'A' * @default_entity_expansion_text_limit}&lt;/p&gt;"
+          source = <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<member>
+#{member_value}
+</member>
+          XML
+
+          parser = REXML::Parsers::PullParser.new(source)
+          events = {}
+          element_name = ''
+          while parser.has_next?
+            event = parser.pull
+            case event.event_type
+            when :start_element
+              element_name = event[0]
+            when :text
+              events[element_name] = event[1]
+            end
+          end
+
+          expected_value = "<p>#{'A' * @default_entity_expansion_text_limit}</p>"
+          assert_equal(expected_value, events['member'].strip)
+          assert_equal(0, parser.entity_expansion_count)
+          assert do
+            events['member'].bytesize > @default_entity_expansion_text_limit
+          end
+        end
+
         def test_entity_expansion_text_limit
           source = <<-XML
 <!DOCTYPE member [

--- a/test/test_sax.rb
+++ b/test/test_sax.rb
@@ -185,6 +185,30 @@ module REXMLTests
           end
         end
 
+        def test_with_only_default_entities
+          member_value = "&lt;p&gt;#{'A' * @default_entity_expansion_text_limit}&lt;/p&gt;"
+          source = <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<member>
+#{member_value}
+</member>
+          XML
+
+          sax = REXML::Parsers::SAX2Parser.new(source)
+          text_value = nil
+          sax.listen(:characters, ["member"]) do |text|
+            text_value = text
+          end
+          sax.parse
+
+          expected_value = "<p>#{'A' * @default_entity_expansion_text_limit}</p>"
+          assert_equal(expected_value, text_value.strip)
+          assert_equal(0, sax.entity_expansion_count)
+          assert do
+            text_value.bytesize > @default_entity_expansion_text_limit
+          end
+        end
+
         def test_entity_expansion_text_limit
           source = <<-XML
 <!DOCTYPE member [

--- a/test/test_stream.rb
+++ b/test/test_stream.rb
@@ -102,7 +102,7 @@ module REXMLTests
 
     def test_with_only_default_entities
       member_value = "&lt;p&gt;#{'A' * @default_entity_expansion_text_limit}&lt;/p&gt;"
-      source = StringIO.new(<<-XML)
+      source = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <member>
 #{member_value}

--- a/test/test_stream.rb
+++ b/test/test_stream.rb
@@ -127,7 +127,6 @@ module REXMLTests
     end
   end
 
-
   # For test_listener
   class RequestReader
     attr_reader :doc


### PR DESCRIPTION
* Change `#entity` to not match against default entities

After this change, the following example will not raise a RuntimeError:

```ruby
# rexml/refactor_entity_example.rb

$LOAD_PATH.unshift(File.expand_path("lib"))

require "rexml/parsers/baseparser"

valid_feed = "&lt;p&gt;#{'A' * 10_240}&lt;/p&gt;"

base_parser = REXML::Parsers::BaseParser.new("")
base_parser.unnormalize(valid_feed) # => "<p>" + "A" * 10_240 + "</p>"
```

Default entities now gets substituted by this block instead

https://github.com/ruby/rexml/blob/e14847cee53d26eb162ad786ba12e3cd7a86fce0/lib/rexml/parsers/baseparser.rb#L560-L563

Close #198