### PR TITLE
Add local entity expansion limit methods

### DIFF
--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -148,8 +148,9 @@ module REXML
     # have been expanded to their values
     def value
       return @unnormalized if @unnormalized
-      @unnormalized = Text::unnormalize( @normalized, doctype )
-      @unnormalized
+
+      @unnormalized = Text::unnormalize(@normalized, doctype,
+                                        entity_expansion_text_limit: @element&.document&.entity_expansion_text_limit)
     end
 
     # The normalized value of this attribute.  That is, the attribute with

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -92,6 +92,7 @@ module REXML
     def initialize( source = nil, context = {} )
       @entity_expansion_count = 0
       @entity_expansion_limit = Security.entity_expansion_limit
+      @entity_expansion_text_limit = Security.entity_expansion_text_limit
       super()
       @context = context
       return if source.nil?
@@ -433,6 +434,7 @@ module REXML
 
     attr_reader :entity_expansion_count
     attr_writer :entity_expansion_limit
+    attr_accessor :entity_expansion_text_limit
 
     def record_entity_expansion
       @entity_expansion_count += 1

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -91,6 +91,7 @@ module REXML
     #
     def initialize( source = nil, context = {} )
       @entity_expansion_count = 0
+      @entity_expansion_limit = Security.entity_expansion_limit
       super()
       @context = context
       return if source.nil?
@@ -431,10 +432,11 @@ module REXML
     end
 
     attr_reader :entity_expansion_count
+    attr_writer :entity_expansion_limit
 
     def record_entity_expansion
       @entity_expansion_count += 1
-      if @entity_expansion_count > Security.entity_expansion_limit
+      if @entity_expansion_count > @entity_expansion_limit
         raise "number of entity expansions exceeded, processing aborted."
       end
     end

--- a/lib/rexml/entity.rb
+++ b/lib/rexml/entity.rb
@@ -71,9 +71,12 @@ module REXML
     # Evaluates to the unnormalized value of this entity; that is, replacing
     # &ent; entities.
     def unnormalized
-      document.record_entity_expansion unless document.nil?
+      document&.record_entity_expansion
+
       return nil if @value.nil?
-      @unnormalized = Text::unnormalize(@value, parent)
+
+      @unnormalized = Text::unnormalize(@value, parent,
+                                        entity_expansion_text_limit: document&.entity_expansion_text_limit)
     end
 
     #once :unnormalized

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -164,6 +164,8 @@ module REXML
         @listeners = []
         @prefixes = Set.new
         @entity_expansion_count = 0
+        @entity_expansion_limit = Security.entity_expansion_limit
+        @entity_expansion_text_limit = Security.entity_expansion_text_limit
       end
 
       def add_listener( listener )
@@ -172,6 +174,8 @@ module REXML
 
       attr_reader :source
       attr_reader :entity_expansion_count
+      attr_writer :entity_expansion_limit
+      attr_writer :entity_expansion_text_limit
 
       def stream=( source )
         @source = SourceFactory.create_from( source )
@@ -585,7 +589,7 @@ module REXML
               end
               re = Private::DEFAULT_ENTITIES_PATTERNS[entity_reference] || /&#{entity_reference};/
               rv.gsub!( re, entity_value )
-              if rv.bytesize > Security.entity_expansion_text_limit
+              if rv.bytesize > @entity_expansion_text_limit
                 raise "entity expansion has grown too large"
               end
             else
@@ -627,7 +631,7 @@ module REXML
 
       def record_entity_expansion(delta=1)
         @entity_expansion_count += delta
-        if @entity_expansion_count > Security.entity_expansion_limit
+        if @entity_expansion_count > @entity_expansion_limit
           raise "number of entity expansions exceeded, processing aborted."
         end
       end

--- a/lib/rexml/parsers/pullparser.rb
+++ b/lib/rexml/parsers/pullparser.rb
@@ -51,6 +51,14 @@ module REXML
         @parser.entity_expansion_count
       end
 
+      def entity_expansion_limit=( limit )
+        @parser.entity_expansion_limit = limit
+      end
+
+      def entity_expansion_text_limit=( limit )
+        @parser.entity_expansion_text_limit = limit
+      end
+
       def each
         while has_next?
           yield self.pull

--- a/lib/rexml/parsers/sax2parser.rb
+++ b/lib/rexml/parsers/sax2parser.rb
@@ -26,6 +26,14 @@ module REXML
         @parser.entity_expansion_count
       end
 
+      def entity_expansion_limit=( limit )
+        @parser.entity_expansion_limit = limit
+      end
+
+      def entity_expansion_text_limit=( limit )
+        @parser.entity_expansion_text_limit = limit
+      end
+
       def add_listener( listener )
         @parser.add_listener( listener )
       end

--- a/lib/rexml/parsers/streamparser.rb
+++ b/lib/rexml/parsers/streamparser.rb
@@ -18,6 +18,14 @@ module REXML
         @parser.entity_expansion_count
       end
 
+      def entity_expansion_limit=( limit )
+        @parser.entity_expansion_limit = limit
+      end
+
+      def entity_expansion_text_limit=( limit )
+        @parser.entity_expansion_text_limit = limit
+      end
+
       def parse
         # entity string
         while true

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -268,7 +268,8 @@ module REXML
     #   u = Text.new( "sean russell", false, nil, true )
     #   u.value   #-> "sean russell"
     def value
-      @unnormalized ||= Text::unnormalize( @string, doctype )
+      @unnormalized ||= Text::unnormalize(@string, doctype,
+                                          entity_expansion_text_limit: document&.entity_expansion_text_limit)
     end
 
     # Sets the contents of this text node.  This expects the text to be
@@ -411,11 +412,12 @@ module REXML
     end
 
     # Unescapes all possible entities
-    def Text::unnormalize( string, doctype=nil, filter=nil, illegal=nil )
+    def Text::unnormalize( string, doctype=nil, filter=nil, illegal=nil, entity_expansion_text_limit: nil )
+      entity_expansion_text_limit ||= Security.entity_expansion_text_limit
       sum = 0
       string.gsub( /\r\n?/, "\n" ).gsub( REFERENCE ) {
         s = Text.expand($&, doctype, filter)
-        if sum + s.bytesize > Security.entity_expansion_text_limit
+        if sum + s.bytesize > entity_expansion_text_limit
           raise "entity expansion has grown too large"
         else
           sum += s.bytesize

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -32,12 +32,10 @@ EOF
 
     class EntityExpansionLimitTest < Test::Unit::TestCase
       def setup
-        @default_entity_expansion_limit = REXML::Security.entity_expansion_limit
         @default_entity_expansion_text_limit = REXML::Security.entity_expansion_text_limit
       end
 
       def teardown
-        REXML::Security.entity_expansion_limit = @default_entity_expansion_limit
         REXML::Security.entity_expansion_text_limit = @default_entity_expansion_text_limit
       end
 
@@ -64,9 +62,8 @@ XML
             doc.root.children.first.value
           end
 
-          REXML::Security.entity_expansion_limit = 100
-          assert_equal(100, REXML::Security.entity_expansion_limit)
           doc = REXML::Document.new(xml)
+          doc.entity_expansion_limit = 100
           assert_raise(RuntimeError.new("number of entity expansions exceeded, processing aborted.")) do
             doc.root.children.first.value
           end
@@ -95,9 +92,8 @@ XML
             doc.root.children.first.value
           end
 
-          REXML::Security.entity_expansion_limit = 100
-          assert_equal(100, REXML::Security.entity_expansion_limit)
           doc = REXML::Document.new(xml)
+          doc.entity_expansion_limit = 100
           assert_raise(RuntimeError.new("number of entity expansions exceeded, processing aborted.")) do
             doc.root.children.first.value
           end
@@ -118,12 +114,12 @@ XML
 </member>
 XML
 
-          REXML::Security.entity_expansion_limit = 4
           doc = REXML::Document.new(xml)
+          doc.entity_expansion_limit = 4
           assert_equal("\na\na a\n<\n", doc.root.children.first.value)
 
-          REXML::Security.entity_expansion_limit = 3
           doc = REXML::Document.new(xml)
+          doc.entity_expansion_limit = 3
           assert_raise(RuntimeError.new("number of entity expansions exceeded, processing aborted.")) do
             doc.root.children.first.value
           end

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -31,14 +31,6 @@ EOF
     end
 
     class EntityExpansionLimitTest < Test::Unit::TestCase
-      def setup
-        @default_entity_expansion_text_limit = REXML::Security.entity_expansion_text_limit
-      end
-
-      def teardown
-        REXML::Security.entity_expansion_text_limit = @default_entity_expansion_text_limit
-      end
-
       class GeneralEntityTest < self
         def test_have_value
           xml = <<XML
@@ -138,8 +130,8 @@ XML
 <member>&a;</member>
           XML
 
-          REXML::Security.entity_expansion_text_limit = 90
           doc = REXML::Document.new(xml)
+          doc.entity_expansion_text_limit = 90
           assert_equal(90, doc.root.children.first.value.bytesize)
         end
       end


### PR DESCRIPTION
GitHub: fix GH-192

Add local entity expansion limit methods.

- `REXML::Document#entity_expansion_limit=`
- `REXML::Document#entity_expansion_text_limit=`
- `REXML::Parsers::SAX2Parser#entity_expansion_limit=`
- `REXML::Parsers::SAX2Parser#entity_expansion_text_limit=`
- `REXML::Parsers::StreamParser#entity_expansion_limit=`
- `REXML::Parsers::StreamParser#entity_expansion_text_limit=`
- `REXML::Parsers::PullParser#entity_expansion_limit=`
- `REXML::Parsers::PullParser#entity_expansion_text_limit=`
