### PR TITLE
Remove strscan dependency declaration from gemspec

### DIFF
--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -58,6 +58,4 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = rdoc_files
 
   spec.required_ruby_version = '>= 2.5.0'
-
-  spec.add_runtime_dependency("strscan")
 end


### PR DESCRIPTION
See discussion in #140. `strscan` is a part of the Ruby standard library in all versions of Ruby supported by REXML.

Fixes #140.