### PR TITLE
Rakefile: workaround Ruby 3.3.5 bug to fix document CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task :default => :test
 namespace :warning do
   desc "Treat warning as error"
   task :error do
+    require "json" # workaround https://bugs.ruby-lang.org/issues/20713
     def Warning.warn(*message, **)
       super
       raise "Treat warning as error:\n" + message.join("\n")


### PR DESCRIPTION
The initial error was a bug here on the rexml side in handling kwargs but after fixing that it revealed that the trigger for what was calling `warn` was https://bugs.ruby-lang.org/issues/20713.

We can workaround it by requiring `json` before hooking into `warn`.