### PR TITLE
Optimize SAX2Parser#get_namespace

### DIFF
--- a/lib/rexml/parsers/sax2parser.rb
+++ b/lib/rexml/parsers/sax2parser.rb
@@ -259,6 +259,8 @@ module REXML
       end
 
       def get_namespace( prefix )
+        return nil if @namespace_stack.empty?
+
         uris = (@namespace_stack.find_all { |ns| not ns[prefix].nil? }) ||
           (@namespace_stack.find { |ns| not ns[nil].nil? })
         uris[-1][prefix] unless uris.nil? or 0 == uris.size


### PR DESCRIPTION
```
RUBYLIB= BUNDLER_ORIG_RUBYLIB= /Users/naitoh/.rbenv/versions/3.3.4/bin/ruby -v -S benchmark-driver /Users/naitoh/ghq/github.com/naitoh/rexml/benchmark/parse.yaml
ruby 3.3.4 (2024-07-09 revision be1089c8ec) [arm64-darwin22]
Calculating -------------------------------------
                         before       after  before(YJIT)  after(YJIT)
                 dom     18.085      17.677        33.086       32.778 i/s -     100.000 times in 5.529372s 5.657097s 3.022471s 3.050832s
                 sax     25.450      26.182        44.797       47.916 i/s -     100.000 times in 3.929249s 3.819475s 2.232309s 2.086982s
                pull     29.160      29.089        55.407       53.531 i/s -     100.000 times in 3.429304s 3.437757s 1.804825s 1.868072s
              stream     29.137      29.055        52.780       51.368 i/s -     100.000 times in 3.432007s 3.441754s 1.894649s 1.946724s

Comparison:
                              dom
        before(YJIT):        33.1 i/s
         after(YJIT):        32.8 i/s - 1.01x  slower
              before:        18.1 i/s - 1.83x  slower
               after:        17.7 i/s - 1.87x  slower

                              sax
         after(YJIT):        47.9 i/s
        before(YJIT):        44.8 i/s - 1.07x  slower
               after:        26.2 i/s - 1.83x  slower
              before:        25.5 i/s - 1.88x  slower

                             pull
        before(YJIT):        55.4 i/s
         after(YJIT):        53.5 i/s - 1.04x  slower
              before:        29.2 i/s - 1.90x  slower
               after:        29.1 i/s - 1.90x  slower

                           stream
        before(YJIT):        52.8 i/s
         after(YJIT):        51.4 i/s - 1.03x  slower
              before:        29.1 i/s - 1.81x  slower
               after:        29.1 i/s - 1.82x  slower
```

- sax
  - YJIT=ON : 1.07x faster
  - YJIT=OFF : 1.03x faster