### PR TITLE
Fix handling with "xml:" prefixed namespace

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -140,6 +140,8 @@ module REXML
         "apos" => [/&apos;/, "&apos;", "'", /'/]
       }
 
+      XML_PREFIXED_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
+
       module Private
         PEREFERENCE_PATTERN = /#{PEREFERENCE}/um
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
@@ -185,7 +187,7 @@ module REXML
         @tags = []
         @stack = []
         @entities = []
-        @namespaces = {"xml" => "http://www.w3.org/XML/1998/namespace"}
+        @namespaces = {"xml" => XML_PREFIXED_NAMESPACE}
         @namespaces_restore_stack = []
       end
 
@@ -790,7 +792,7 @@ module REXML
             @source.match(/\s*/um, true)
             if prefix == "xmlns"
               if local_part == "xml"
-                if value != "http://www.w3.org/XML/1998/namespace"
+                if value != XML_PREFIXED_NAMESPACE
                   msg = "The 'xml' prefix must not be bound to any other namespace "+
                     "(http://www.w3.org/TR/REC-xml-names/#ns-decl)"
                   raise REXML::ParseException.new( msg, @source, self )

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -140,8 +140,6 @@ module REXML
         "apos" => [/&apos;/, "&apos;", "'", /'/]
       }
 
-      XML_PREFIXED_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
-
       module Private
         PEREFERENCE_PATTERN = /#{PEREFERENCE}/um
         TAG_PATTERN = /((?>#{QNAME_STR}))\s*/um
@@ -158,6 +156,7 @@ module REXML
         default_entities.each do |term|
           DEFAULT_ENTITIES_PATTERNS[term] = /&#{term};/
         end
+        XML_PREFIXED_NAMESPACE = "http://www.w3.org/XML/1998/namespace"
       end
       private_constant :Private
 
@@ -187,7 +186,7 @@ module REXML
         @tags = []
         @stack = []
         @entities = []
-        @namespaces = {"xml" => XML_PREFIXED_NAMESPACE}
+        @namespaces = {"xml" => Private::XML_PREFIXED_NAMESPACE}
         @namespaces_restore_stack = []
       end
 
@@ -792,7 +791,7 @@ module REXML
             @source.match(/\s*/um, true)
             if prefix == "xmlns"
               if local_part == "xml"
-                if value != XML_PREFIXED_NAMESPACE
+                if value != Private::XML_PREFIXED_NAMESPACE
                   msg = "The 'xml' prefix must not be bound to any other namespace "+
                     "(http://www.w3.org/TR/REC-xml-names/#ns-decl)"
                   raise REXML::ParseException.new( msg, @source, self )

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -185,7 +185,7 @@ module REXML
         @tags = []
         @stack = []
         @entities = []
-        @namespaces = {}
+        @namespaces = {"xml" => "http://www.w3.org/XML/1998/namespace"}
         @namespaces_restore_stack = []
       end
 

--- a/test/parser/test_base_parser.rb
+++ b/test/parser/test_base_parser.rb
@@ -43,20 +43,20 @@ module REXMLTests
       5.times {parser.pull}
 
       html = parser.pull
-      assert_equal [:start_element,
+      assert_equal([:start_element,
                     "html",
                     {"xmlns" => "http://www.w3.org/1999/xhtml",
                      "xml:lang" => "en",
                      "lang" => "en"}],
-                   html
+                   html)
 
       15.times {parser.pull}
 
       p = parser.pull
-      assert_equal [:start_element,
+      assert_equal([:start_element,
                     "p",
                     {"xml:lang" => "ja", "lang" => "ja"}],
-                   p
+                   p)
     end
   end
 end

--- a/test/parser/test_base_parser.rb
+++ b/test/parser/test_base_parser.rb
@@ -23,5 +23,40 @@ module REXMLTests
         parser.position < xml.bytesize
       end
     end
+
+    def test_attribute_prefixed_by_xml
+      xml = <<-XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE html>
+        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+          <head>
+            <title>XHTML Document</title>
+          </head>
+          <body>
+            <h1>XHTML Document</h1>
+            <p xml:lang="ja" lang="ja">この段落は日本語です。</p>
+          </body>
+        </html>
+      XML
+
+      parser = REXML::Parsers::BaseParser.new(xml)
+      5.times {parser.pull}
+
+      html = parser.pull
+      assert_equal [:start_element,
+                    "html",
+                    {"xmlns" => "http://www.w3.org/1999/xhtml",
+                     "xml:lang" => "en",
+                     "lang" => "en"}],
+                   html
+
+      15.times {parser.pull}
+
+      p = parser.pull
+      assert_equal [:start_element,
+                    "p",
+                    {"xml:lang" => "ja", "lang" => "ja"}],
+                   p
+    end
   end
 end


### PR DESCRIPTION
Hello,

I found parsing XHTML documents like below fails since v3.3.3:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
  <head>
    <title>XHTML Document</title>
  </head>
  <body>
    <h1>XHTML Document</h1>
    <p xml:lang="ja" lang="ja">この段落は日本語です。</p>
  </body>
</html>
```

[XML namespace spec][spec] is a little bit ambiguous but document above is valid according to an [article W3C serves][article].

I fixed the parsing algorithm. Can you review it?

As an aside, `<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">` style language declaration is often used in XHTML files included in EPUB files because [sample EPUB files][samples] provided by IDPF, former EPUB spec authority, use the style.

[spec]: https://www.w3.org/TR/REC-xml-names/#defaulting
[article]: https://www.w3.org/International/questions/qa-html-language-declarations#attributes
[samples]: https://github.com/IDPF/epub3-samples