### PR TITLE
Stop requiring stringio dynamically

### DIFF
--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -1,8 +1,8 @@
 # coding: US-ASCII
 # frozen_string_literal: false
 
-require "strscan"
 require "stringio"
+require "strscan"
 
 require_relative 'encoding'
 

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: false
 
 require "strscan"
+require "stringio"
 
 require_relative 'encoding'
 
@@ -45,7 +46,6 @@ module REXML
           arg.respond_to? :eof?
         IOSource.new(arg)
       elsif arg.respond_to? :to_str
-        require 'stringio'
         IOSource.new(StringIO.new(arg))
       elsif arg.kind_of? Source
         arg


### PR DESCRIPTION
`SourceFactory::create_from(String)` will always run the `require 'stringio'` operation. This prevents a multi-threaded JRuby application from parsing xml on separate threads concurrently given that `require` will pass through a synchronized piece of code.

An experiment in removing this `require` lead to a 10x performance improvement on 10 threads parsing incoming strings on xml. For more details see https://github.com/logstash-plugins/logstash-filter-xml/issues/83