### PR TITLE
parser pull: Add support for reusing parser

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -181,6 +181,10 @@ module REXML
 
       def stream=( source )
         @source = SourceFactory.create_from( source )
+        reset
+      end
+
+      def reset
         @closed = nil
         @have_root = false
         @document_status = nil

--- a/lib/rexml/parsers/pullparser.rb
+++ b/lib/rexml/parsers/pullparser.rb
@@ -93,6 +93,10 @@ module REXML
       def unshift token
         @my_stack.unshift token
       end
+
+      def reset
+        @parser.reset
+      end
     end
 
     # A parsing event.  The contents of the event are accessed as an +Array?,

--- a/test/test_pullparser.rb
+++ b/test/test_pullparser.rb
@@ -156,6 +156,39 @@ module REXMLTests
       assert_equal( 0, names.length )
     end
 
+    def test_reset
+      xml_chunks = [
+        "<message>First valid and complete message</message>",
+        "<message>Second valid and complete message</message>",
+        "<message>Third valid and complete message</message>"
+      ]
+
+      messages = []
+
+      IO.pipe do |reader, writer|
+        xml_chunks.each do |chunk|
+          writer.write(chunk)
+        end
+        writer.close
+
+        parser = REXML::Parsers::PullParser.new(reader)
+        while parser.has_next?
+          parser.pull
+          message_text = parser.pull
+          messages << message_text[0]
+          parser.pull
+          parser.reset
+        end
+      end
+
+      assert_equal(
+        messages,
+        ["First valid and complete message",
+         "Second valid and complete message",
+         "Third valid and complete message"]
+      )
+    end
+
     class EntityExpansionLimitTest < Test::Unit::TestCase
       class GeneralEntityTest < self
         def test_have_value


### PR DESCRIPTION
GitHub: Fix GH-214 

This is for parsing XML documents stream. We can use one parser to parse multiple XML documents with this feature.