### PR TITLE
Fix error handling when parsing XML via IO.pipe

### DIFF
--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -321,7 +321,7 @@ module REXML
         rescue
         end
         @er_source.seek(pos)
-      rescue IOError
+      rescue IOError, SystemCallError
         pos = -1
         line = -1
       end

--- a/test/parse/test_text.rb
+++ b/test/parse/test_text.rb
@@ -6,10 +6,7 @@ module REXMLTests
     class TestInvalid < self
       def test_text_only
         exception = assert_raise(REXML::ParseException) do
-          parser = REXML::Parsers::BaseParser.new('a')
-          while parser.has_next?
-            parser.pull
-          end
+          REXML::Parsers::BaseParser.new('a').pull
         end
 
         assert_equal(<<~DETAIL.chomp, exception.to_s)
@@ -19,6 +16,25 @@ module REXMLTests
           Last 80 unconsumed characters:
 
         DETAIL
+      end
+
+      def test_text_only_with_io_pipe
+        IO.pipe do |reader, writer|
+          writer.write('a')
+          writer.close
+
+          exception = assert_raise(REXML::ParseException) do
+            REXML::Parsers::BaseParser.new(reader).pull
+          end
+
+          assert_equal(<<~DETAIL.chomp, exception.to_s)
+            Malformed XML: Content at the start of the document (got 'a')
+            Line: -1
+            Position: -1
+            Last 80 unconsumed characters:
+
+          DETAIL
+        end
       end
 
       def test_before_root


### PR DESCRIPTION
## Why?

If via IO.pipe, `IOError` exception is not raised, but `Errno::ESPIPE` or `Errno::EPIPE` or `Errno::EINVAL` exception is raised.

- CRuby
```
@er_source.pos
#=> Errno::ESPIPE Exception: Illegal seek
```

- CRuby (Windows (Ruby 2.6 or earlier))
```
@er_source.pos
#=> Errno::EINVAL: Invalid argument
```

- JRuby
```
@er_source.pos
#=> Errno::EPIPE: Broken pipe - No message available
```