### PR TITLE
test: Fix NameError: uninitialized constant REXML::Parsers::PullParser

### DIFF
--- a/test/parse/test_character_reference.rb
+++ b/test/parse/test_character_reference.rb
@@ -2,6 +2,7 @@ require "test/unit"
 require "core_assertions"
 
 require "rexml/document"
+require "rexml/parsers/pullparser"
 
 module REXMLTests
   class TestParseCharacterReference < Test::Unit::TestCase


### PR DESCRIPTION
This commit fixes the following NameError when running only specific test file test/parse/test_character_reference.rb.

```
$ ruby test/parse/test_character_reference.rb -v
Loaded suite test/parse/test_character_reference
Started
REXMLTests::TestParseCharacterReference:
  test_hex_precedding_zero:           E
===========================================================================================
Error: test_hex_precedding_zero(REXMLTests::TestParseCharacterReference): NameError: uninitialized constant REXML::Parsers::PullParser
test/parse/test_character_reference.rb:18:in 'REXMLTests::TestParseCharacterReference#test_hex_precedding_zero'
===========================================================================================
: (0.001470)
  test_linear_performance_many_preceding_zeros:       .: (0.033970)

Finished in 0.036068018 seconds.
-------------------------------------------------------------------------------------------
2 tests, 15 assertions, 0 failures, 1 errors, 0 pendings, 0 omissions, 0 notifications
50% passed
-------------------------------------------------------------------------------------------
55.45 tests/s, 415.88 assertions/s
```