### PR TITLE
Update node.rb  required transitive.rb, so it can be found.

### DIFF
--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -388,7 +388,6 @@ module REXML
       end
       formatter = if indent > -1
           if transitive
-            require_relative "formatters/transitive"
             REXML::Formatters::Transitive.new( indent, ie_hack )
           else
             REXML::Formatters::Pretty.new( indent, ie_hack )

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -388,6 +388,7 @@ module REXML
       end
       formatter = if indent > -1
           if transitive
+            
             REXML::Formatters::Transitive.new( indent, ie_hack )
           else
             REXML::Formatters::Pretty.new( indent, ie_hack )

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -1505,7 +1505,7 @@ module REXML
       Kernel.warn("#{self.class.name}.write is deprecated.  See REXML::Formatters", uplevel: 1)
       formatter = if indent > -1
           if transitive
-            require_relative "formatters/transitive"
+            require_relative "formatters/transitive"  
             REXML::Formatters::Transitive.new( indent, ie_hack )
           else
             REXML::Formatters::Pretty.new( indent, ie_hack )

--- a/lib/rexml/node.rb
+++ b/lib/rexml/node.rb
@@ -2,6 +2,7 @@
 require_relative "parseexception"
 require_relative "formatters/pretty"
 require_relative "formatters/default"
+require_relative "formatters/transitive"
 
 module REXML
   # Represents a node in the tree.  Nodes are never encountered except as

--- a/lib/rexml/node.rb
+++ b/lib/rexml/node.rb
@@ -2,7 +2,6 @@
 require_relative "parseexception"
 require_relative "formatters/pretty"
 require_relative "formatters/default"
-require_relative "formatters/transitive"
 
 module REXML
   # Represents a node in the tree.  Nodes are never encountered except as


### PR DESCRIPTION
I recently tried to use REXML::Formatters::Transitive, and its not included in REXML.