### PR TITLE
Update transitive.rb

### DIFF
--- a/lib/rexml/formatters/transitive.rb
+++ b/lib/rexml/formatters/transitive.rb
@@ -12,7 +12,7 @@ module REXML
     # Note that this is only useful if the original XML is not already
     # formatted.  Since this formatter does not alter whitespace nodes, the
     # results of formatting already formatted XML will be odd.
-    class Transitive < REXML::Formatters::Pretty
+    class Transitive < Pretty
       def write_text( node, output )
         output << node.to_s()
       end

--- a/lib/rexml/formatters/transitive.rb
+++ b/lib/rexml/formatters/transitive.rb
@@ -12,44 +12,7 @@ module REXML
     # Note that this is only useful if the original XML is not already
     # formatted.  Since this formatter does not alter whitespace nodes, the
     # results of formatting already formatted XML will be odd.
-    class Transitive < Default
-      def initialize( indentation=2, ie_hack=false )
-        @indentation = indentation
-        @level = 0
-        @ie_hack = ie_hack
-      end
-
-      protected
-      def write_element( node, output )
-        output << "<#{node.expanded_name}"
-
-        node.attributes.each_attribute do |attr|
-          output << " "
-          attr.write( output )
-        end unless node.attributes.empty?
-
-        output << "\n"
-        output << ' '*@level
-        if node.children.empty?
-          output << " " if @ie_hack
-          output << "/"
-        else
-          output << ">"
-          # If compact and all children are text, and if the formatted output
-          # is less than the specified width, then try to print everything on
-          # one line
-          @level += @indentation
-          node.children.each { |child|
-            write( child, output )
-          }
-          @level -= @indentation
-          output << "</#{node.expanded_name}"
-          output << "\n"
-          output << ' '*@level
-        end
-        output << ">"
-      end
-
+    class Transitive < REXML::Formatters::Pretty
       def write_text( node, output )
         output << node.to_s()
       end

--- a/lib/rexml/formatters/transitive.rb
+++ b/lib/rexml/formatters/transitive.rb
@@ -14,7 +14,7 @@ module REXML
     # results of formatting already formatted XML will be odd.
     class Transitive < Pretty
       def write_text( node, output )
-        output << node.to_s()
+        output << node.to_s().strip
       end
     end
   end


### PR DESCRIPTION
GitHub: fix GH-228

This makes Transitive.rb do exactly what the docs say it should do.  It outputs Pretty xml except for text nodes which are left untouched.  If you read the issue that I posted, you can see that the current Transitive output is garbled.  Also, this has the benefit of being initialized using Prestty.rb, initialize method for simplicity.