### PR TITLE
Added rdoc as a development dependency (for Ruby 3.5+)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development do
   # depends on "ostruct" explicitly.
   gem "ostruct"
   gem "rake"
+  gem "rdoc"
 end
 
 group :benchmark do


### PR DESCRIPTION
Ruby 3.5+ requires that rdoc explicitly be declared as a dependency
Should sort out GitHub Actions that are failing due to this