### PR TITLE
Changed benchmark target to Ruby latest

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.3'
+          - 'ruby'
         runs-on:
           - ubuntu-latest
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Ruby 3.4 has been released, we will change our benchmark target to Ruby latest(3.4).