### PR TITLE
Improve CDATA parse performance

### DIFF
--- a/benchmark/parse_cdata.yaml
+++ b/benchmark/parse_cdata.yaml
@@ -1,0 +1,50 @@
+loop_count: 100
+contexts:
+  - gems:
+      rexml: 3.2.6
+    require: false
+    prelude: require 'rexml'
+  - name: master
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+  - name: 3.2.6(YJIT)
+    gems:
+      rexml: 3.2.6
+    require: false
+    prelude: |
+      require 'rexml'
+      RubyVM::YJIT.enable
+  - name: master(YJIT)
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+      RubyVM::YJIT.enable
+
+prelude: |
+  require 'rexml/document'
+  require 'rexml/parsers/sax2parser'
+  require 'rexml/parsers/pullparser'
+  require 'rexml/parsers/streamparser'
+  require 'rexml/streamlistener'
+
+  def build_xml(size)
+    xml = "<?xml version=\"1.0\"?>\n" +
+           "<root>Test</root>\n" +
+           "<![CDATA[" + "a" * size + "]]>\n"
+  end
+  xml = build_xml(100000)
+
+  class Listener
+    include REXML::StreamListener
+  end
+
+benchmark:
+  'dom'        : REXML::Document.new(xml)
+  'sax'        : REXML::Parsers::SAX2Parser.new(xml).parse
+  'pull'       : |
+    parser = REXML::Parsers::PullParser.new(xml)
+    while parser.has_next?
+      parser.pull
+    end
+  'stream'     : REXML::Parsers::StreamParser.new(xml, Listener.new).parse

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -471,9 +471,13 @@ module REXML
                 end
 
                 return [ :comment, md[1] ]
-              else
-                md = @source.match(/\[CDATA\[(.*?)\]\]>/um, true)
-                return [ :cdata, md[1] ] if md
+              elsif @source.match?("[CDATA[", true)
+                text = @source.read_until("]]>")
+                if text.chomp!("]]>")
+                  return [ :cdata, text ]
+                else
+                  raise REXML::ParseException.new("Malformed CDATA: Missing end ']]>'", @source)
+                end
               end
               raise REXML::ParseException.new( "Declarations can only occur "+
                 "in the doctype declaration.", @source)

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -67,7 +67,7 @@ module REXML
     module Private
       SCANNER_RESET_SIZE = 100000
       PRE_DEFINED_TERM_PATTERNS = {}
-      pre_defined_terms = ["'", '"', "<"]
+      pre_defined_terms = ["'", '"', "<", "]]>"]
       if StringScanner::Version < "3.1.1"
         pre_defined_terms.each do |term|
           PRE_DEFINED_TERM_PATTERNS[term] = /#{Regexp.escape(term)}/

--- a/test/parse/test_cdata.rb
+++ b/test/parse/test_cdata.rb
@@ -7,10 +7,28 @@ module REXMLTests
   class TestParseCData < Test::Unit::TestCase
     include Test::Unit::CoreAssertions
 
+    def parse(xml)
+      REXML::Document.new(xml)
+    end
+
     def test_linear_performance_gt
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new('<description><![CDATA[ ' + ">" * n + ' ]]></description>')
+        parse('<description><![CDATA[ ' + ">" * n + ' ]]></description>')
+      end
+    end
+
+    class TestInvalid < self
+      def test_unclosed_cdata
+        exception = assert_raise(REXML::ParseException) do
+          parse("<root><![CDATA[a]></root>")
+        end
+        assert_equal(<<~DETAIL, exception.to_s)
+          Malformed CDATA: Missing end ']]>'
+          Line: 1
+          Position: 25
+          Last 80 unconsumed characters:
+        DETAIL
       end
     end
   end


### PR DESCRIPTION
## Why?

GitHub: fix #243

## Benchmark (Comparison with rexml 3.4.1)
```
$ benchmark-driver benchmark/parse_cdata.yaml
Calculating -------------------------------------
                     rexml 3.4.1      master  3.4.1(YJIT)  master(YJIT)
                 dom     648.361      1.178k      591.590        1.046k i/s -     100.000 times in 0.154235s 0.084913s 0.169036s 0.095627s
                 sax     699.061      1.378k      651.148        1.196k i/s -     100.000 times in 0.143049s 0.072549s 0.153575s 0.083611s
                pull     699.271      1.379k      660.275        1.210k i/s -     100.000 times in 0.143006s 0.072527s 0.151452s 0.082622s
              stream     701.725      1.383k      659.483        1.228k i/s -     100.000 times in 0.142506s 0.072307s 0.151634s 0.081455s

Comparison:
                              dom
              master:      1177.7 i/s
        master(YJIT):      1045.7 i/s - 1.13x  slower
         rexml 3.4.1:       648.4 i/s - 1.82x  slower
         3.4.1(YJIT):       591.6 i/s - 1.99x  slower

                              sax
              master:      1378.4 i/s
        master(YJIT):      1196.0 i/s - 1.15x  slower
         rexml 3.4.1:       699.1 i/s - 1.97x  slower
         3.4.1(YJIT):       651.1 i/s - 2.12x  slower

                             pull
              master:      1378.8 i/s
        master(YJIT):      1210.3 i/s - 1.14x  slower
         rexml 3.4.1:       699.3 i/s - 1.97x  slower
         3.4.1(YJIT):       660.3 i/s - 2.09x  slower

                           stream
              master:      1383.0 i/s
        master(YJIT):      1227.7 i/s - 1.13x  slower
         rexml 3.4.1:       701.7 i/s - 1.97x  slower
         3.4.1(YJIT):       659.5 i/s - 2.10x  slower
```
- YJIT=ON : 1.76x - 1.83x faster
- YJIT=OFF : 1.82x - 1.97x faster