### PR TITLE
Improve comment parse performance

### DIFF
--- a/benchmark/parse_comment.yaml
+++ b/benchmark/parse_comment.yaml
@@ -1,0 +1,36 @@
+loop_count: 100
+contexts:
+  - gems:
+      rexml: 3.2.6
+    require: false
+    prelude: require 'rexml'
+  - name: master
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+  - name: 3.2.6(YJIT)
+    gems:
+      rexml: 3.2.6
+    require: false
+    prelude: |
+      require 'rexml'
+      RubyVM::YJIT.enable
+  - name: master(YJIT)
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+      RubyVM::YJIT.enable
+
+prelude: |
+  require 'rexml/document'
+
+  SIZE = 100000
+
+  top_level_xml     = "<!--" + "a" * SIZE + "-->\n"
+  in_doctype_xml    = "<!DOCTYPE foo [<!--" + "a" * SIZE + "-->]>"
+  after_doctype_xml = "<root/><!--" + "a" * SIZE + "-->"
+
+benchmark:
+  'top_level'      : REXML::Document.new(top_level_xml)
+  'in_doctype'     : REXML::Document.new(in_doctype_xml)
+  'after_doctype'  : REXML::Document.new(after_doctype_xml)

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -17,7 +17,7 @@ module REXMLTests
           parse("<!--")
         end
         assert_equal(<<~DETAIL, exception.to_s)
-          Unclosed comment
+          Unclosed comment: Missing end '-->'
           Line: 1
           Position: 4
           Last 80 unconsumed characters:
@@ -48,6 +48,18 @@ module REXMLTests
         DETAIL
       end
 
+      def test_doctype_unclosed_comment
+        exception = assert_raise(REXML::ParseException) do
+          parse("<!DOCTYPE foo [<!--")
+        end
+        assert_equal(<<~DETAIL, exception.to_s)
+          Unclosed comment: Missing end '-->'
+          Line: 1
+          Position: 19
+          Last 80 unconsumed characters:
+        DETAIL
+      end
+
       def test_doctype_malformed_comment_inner
         exception = assert_raise(REXML::ParseException) do
           parse("<!DOCTYPE foo [<!-- -- -->")
@@ -72,16 +84,15 @@ module REXMLTests
         DETAIL
       end
 
-      def test_after_doctype_malformed_comment_short
+      def test_after_doctype_unclosed_comment
         exception = assert_raise(REXML::ParseException) do
           parse("<a><!-->")
         end
-        assert_equal(<<~DETAIL.chomp, exception.to_s)
-          Malformed comment
+        assert_equal(<<~DETAIL, exception.to_s)
+          Unclosed comment: Missing end '-->'
           Line: 1
           Position: 8
           Last 80 unconsumed characters:
-          -->
         DETAIL
       end
 


### PR DESCRIPTION
## Benchmark (Comparison with rexml 3.4.1)
```
$ benchmark-driver benchmark/parse_comment.yaml
Calculating -------------------------------------
                     rexml 3.4.1      master  3.4.1(YJIT)  master(YJIT)
           top_level     999.440      5.058k      922.416        3.340k i/s -     100.000 times in 0.100056s 0.019770s 0.108411s 0.029936s
          in_doctype      1.063k      4.890k      980.498        3.341k i/s -     100.000 times in 0.094116s 0.020449s 0.101989s 0.029927s
       after_doctype     638.321      1.304k      603.952        1.153k i/s -     100.000 times in 0.156661s 0.076710s 0.165576s 0.086748s

Comparison:
                        top_level
              master:      5058.2 i/s
        master(YJIT):      3340.5 i/s - 1.51x  slower
         rexml 3.4.1:       999.4 i/s - 5.06x  slower
         3.4.1(YJIT):       922.4 i/s - 5.48x  slower

                       in_doctype
              master:      4890.2 i/s
        master(YJIT):      3341.5 i/s - 1.46x  slower
         rexml 3.4.1:      1062.5 i/s - 4.60x  slower
         3.4.1(YJIT):       980.5 i/s - 4.99x  slower

                    after_doctype
              master:      1303.6 i/s
        master(YJIT):      1152.8 i/s - 1.13x  slower
         rexml 3.4.1:       638.3 i/s - 2.04x  slower
         3.4.1(YJIT):       604.0 i/s - 2.16x  slower
```

- YJIT=ON : 1.90x - 3.62x faster
- YJIT=OFF : 2.04x - 5.06x faster