### PR TITLE
Raise appropriate exception when failing to match start tag in DOCTYPE

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -412,6 +412,8 @@ module REXML
               return [:notationdecl, name, *id]
             elsif @source.match?("--", true)
               return [ :comment, process_comment ]
+            else
+              raise REXML::ParseException.new("Malformed node: Started with '<!' but not a comment nor ELEMENT,ENTITY,ATTLIST,NOTATION", @source)
             end
           elsif match = @source.match(/(%.*?;)\s*/um, true)
             return [ :externalentity, match[1] ]

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -420,8 +420,7 @@ module REXML
           elsif @source.match?(/\]\s*>/um, true)
             @document_status = :after_doctype
             return [ :end_doctype ]
-          end
-          if @document_status == :in_doctype
+          else
             raise ParseException.new("Malformed DOCTYPE: invalid declaration", @source)
           end
         end

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -48,6 +48,19 @@ module REXMLTests
         DETAIL
       end
 
+      def test_doctype_malformed_node
+        exception = assert_raise(REXML::ParseException) do
+          parse("<!DOCTYPE foo [<!a")
+        end
+        assert_equal(<<~DETAIL.chomp, exception.to_s)
+          Malformed node: Started with '<!' but not a comment nor ELEMENT,ENTITY,ATTLIST,NOTATION
+          Line: 1
+          Position: 18
+          Last 80 unconsumed characters:
+          a
+        DETAIL
+      end
+
       def test_doctype_unclosed_comment
         exception = assert_raise(REXML::ParseException) do
           parse("<!DOCTYPE foo [<!--")


### PR DESCRIPTION
## Why?
Added exception to make the process easier to understand.