### PR TITLE
Improve using `//` in XPath performance

### DIFF
--- a/benchmark/xpath.yaml
+++ b/benchmark/xpath.yaml
@@ -1,0 +1,32 @@
+loop_count: 100
+contexts:
+  - gems:
+      rexml: 3.2.6
+    require: false
+    prelude: require 'rexml'
+  - name: master
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+  - name: 3.2.6(YJIT)
+    gems:
+      rexml: 3.2.6
+    require: false
+    prelude: |
+      require 'rexml'
+      RubyVM::YJIT.enable
+  - name: master(YJIT)
+    prelude: |
+      $LOAD_PATH.unshift(File.expand_path("lib"))
+      require 'rexml'
+      RubyVM::YJIT.enable
+
+prelude: |
+  require 'rexml/document'
+
+  DEPTH = 100
+  xml   = '<a>' * DEPTH + '</a>' * DEPTH
+  doc   = REXML::Document.new(xml)
+
+benchmark:
+  "REXML::XPath.match(REXML::Document.new(xml), 'a//a')" : REXML::XPath.match(doc, "a//a")

--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -206,6 +206,10 @@ module REXML
       path += "/@#{self.expanded_name}"
       return path
     end
+
+    def document
+      @element&.document
+    end
   end
 end
 #vim:ts=2 sw=2 noexpandtab:

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -448,6 +448,20 @@ module REXML
     end
 
     private
+
+    attr_accessor :namespaces_cache
+
+    # New document level cache is created and available in this block.
+    # This API is thread unsafe. Users can't change this document in this block.
+    def enable_cache
+      @namespaces_cache = {}
+      begin
+        yield
+      ensure
+        @namespaces_cache = nil
+      end
+    end
+
     def build( source )
       Parsers::TreeParser.new( source, self ).parse
     end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -653,17 +653,22 @@ Last 80 unconsumed characters:
       assert_equal "<sean:blah>Some text</sean:blah>", out
     end
 
-
     def test_add_namespace
       e = Element.new 'a'
+      assert_equal("", e.namespace)
+      assert_nil(e.namespace('foo'))
       e.add_namespace 'someuri'
       e.add_namespace 'foo', 'otheruri'
       e.add_namespace 'xmlns:bar', 'thirduri'
-      assert_equal 'someuri', e.attributes['xmlns']
-      assert_equal 'otheruri', e.attributes['xmlns:foo']
-      assert_equal 'thirduri', e.attributes['xmlns:bar']
+      assert_equal("someuri", e.namespace)
+      assert_equal("otheruri", e.namespace('foo'))
+      assert_equal("otheruri", e.namespace('xmlns:foo'))
+      assert_equal("thirduri", e.namespace('bar'))
+      assert_equal("thirduri", e.namespace('xmlns:bar'))
+      assert_equal('someuri', e.attributes['xmlns'])
+      assert_equal('otheruri', e.attributes['xmlns:foo'])
+      assert_equal('thirduri', e.attributes['xmlns:bar'])
     end
-
 
     def test_big_documentation
       d = File.open(fixture_path("documentation.xml")) {|f| Document.new f }
@@ -764,9 +769,15 @@ Last 80 unconsumed characters:
 
     def test_delete_namespace
       doc = Document.new "<a xmlns='1' xmlns:x='2'/>"
+      assert_equal("1", doc.root.namespace)
+      assert_equal("2", doc.root.namespace('x'))
+      assert_equal("2", doc.root.namespace('xmlns:x'))
       doc.root.delete_namespace
       doc.root.delete_namespace 'x'
-      assert_equal "<a/>", doc.to_s
+      assert_equal("<a/>", doc.to_s)
+      assert_equal("", doc.root.namespace)
+      assert_nil(doc.root.namespace('x'))
+      assert_nil(doc.root.namespace('xmlns:x'))
     end
 
     def test_each_element_with_attribute

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1193,6 +1193,16 @@ EOF
       assert_equal( 1,  XPath.match( d, "//x:*" ).size )
     end
 
+    def test_namespaces_cache
+      doc = Document.new("<a xmlns='1'><b/></a>")
+      assert_equal("<b/>", XPath.first(doc, "//b[namespace-uri()='1']").to_s)
+      assert_nil(XPath.first(doc, "//b[namespace-uri()='']"))
+
+      doc.root.delete_namespace
+      assert_nil(XPath.first(doc, "//b[namespace-uri()='1']"))
+      assert_equal("<b/>", XPath.first(doc, "//b[namespace-uri()='']").to_s)
+    end
+
     def test_ticket_71
       doc = Document.new(%Q{<root xmlns:ns1="xyz" xmlns:ns2="123"><element ns1:attrname="foo" ns2:attrname="bar"/></root>})
       el = doc.root.elements[1]


### PR DESCRIPTION
When using `//` in XPath, the deeper the tag hierarchy, the slower it becomes due to the namespace acquisition process.
Caching namespace information improves performance when using `//` with XPath.

## Benchmark (Comparison with rexml 3.4.1)

```
$ benchmark-driver benchmark/xpath.yaml
Calculating -------------------------------------
                                                     rexml 3.4.1      master  3.4.1(YJIT)  master(YJIT)
REXML::XPath.match(REXML::Document.new(xml), 'a//a')      29.215     234.909      108.945       492.410 i/s -     100.000 times in 3.422925s 0.425697s 0.917898s 0.203083s

Comparison:
             REXML::XPath.match(REXML::Document.new(xml), 'a//a')
                                        master(YJIT):       492.4 i/s
                                              master:       234.9 i/s - 2.10x  slower
                                         3.4.1(YJIT):       108.9 i/s - 4.52x  slower
                                         rexml 3.4.1:        29.2 i/s - 16.85x  slower
```

- YJIT=ON : 4.52x faster
- YJIT=OFF : 8.04x faster