### PR TITLE
Fix reverse sort in xpath_parser

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -671,7 +671,7 @@ module REXML
         if order == :forward
           index
         else
-          -index
+          index.map(&:-@)
         end
       end
       ordered.collect do |_index, node|

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -409,6 +409,10 @@ module REXMLTests
       assert_equal("c", matches[0].name)
       assert_equal("b", matches[1].name)
 
+      d = REXML::Document.new("<a><b/><c/><d/><d/></a>")
+      cs = REXML::XPath.match(d, "a/d/preceding::node()")
+      assert_equal(["d", "c", "c", "b", "b"], cs.map(&:name))
+
       s = "<a><b><c id='1'/></b><b><b><c id='2'/><c id='3'/></b><c id='4'/></b><c id='NOMATCH'><c id='5'/></c></a>"
       d = REXML::Document.new(s)
       c = REXML::XPath.match( d, "//c[@id = '5']")

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -409,15 +409,17 @@ module REXMLTests
       assert_equal("c", matches[0].name)
       assert_equal("b", matches[1].name)
 
-      d = REXML::Document.new("<a><b/><c/><d/><d/></a>")
-      cs = REXML::XPath.match(d, "a/d/preceding::node()")
-      assert_equal(["d", "c", "c", "b", "b"], cs.map(&:name))
-
       s = "<a><b><c id='1'/></b><b><b><c id='2'/><c id='3'/></b><c id='4'/></b><c id='NOMATCH'><c id='5'/></c></a>"
       d = REXML::Document.new(s)
       c = REXML::XPath.match( d, "//c[@id = '5']")
       cs = REXML::XPath.match( c, "preceding::c" )
       assert_equal( 4, cs.length )
+    end
+
+    def test_preceding_sibling
+      d = REXML::Document.new("<a><b><c/><d/><x/></b><b><e/><x/></b></a>")
+      matches = REXML::XPath.match(d, "a/b/x/preceding-sibling::node()")
+      assert_equal(["e", "d", "c"], matches.map(&:name))
     end
 
     def test_following


### PR DESCRIPTION
The code below was failing with `REXML::XPathParser#sort': undefined method '-@' for an instance of Array`
```ruby
d = REXML::Document.new("<a><b><c/><d/><x/></b><b><e/><x/></b></a>")
matches = REXML::XPath.match(d, "a/b/x/preceding-sibling::node()")
# Before: error
# After: [<e/>, <d/>, <c/>]
```
This pull request will fix it.
