### PR TITLE
Improve `Text.check` performance

### DIFF
--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -173,7 +173,7 @@ module REXML
       @element = element
 
       if @normalized
-        Text.check( @normalized, NEEDS_A_SECOND_CHECK, doctype )
+        Text.check( @normalized, NEEDS_A_SECOND_CHECK )
       end
 
       self

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -104,16 +104,16 @@ module REXML
       @entity_filter = entity_filter if entity_filter
       clear_cache
 
-      Text.check(@string, illegal, doctype) if @raw
+      Text.check(@string, illegal) if @raw
     end
 
     def parent= parent
       super(parent)
-      Text.check(@string, NEEDS_A_SECOND_CHECK, doctype) if @raw and @parent
+      Text.check(@string, NEEDS_A_SECOND_CHECK) if @raw and @parent
     end
 
     # check for illegal characters
-    def Text.check string, pattern, doctype
+    def Text.check string, pattern, doctype = nil
 
       # illegal anywhere
       if !string.match?(VALID_XML_CHARS)

--- a/test/test_text_check.rb
+++ b/test/test_text_check.rb
@@ -4,7 +4,7 @@ module REXMLTests
   class TextCheckTester < Test::Unit::TestCase
 
     def check(string)
-      REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK, nil)
+      REXML::Text.check(string, REXML::Text::NEEDS_A_SECOND_CHECK)
     end
 
     def assert_check(string)


### PR DESCRIPTION
The doctype parameter of Text.check is not being used.
Changing the doctype parameter to an optional parameter improves the parsing speed of the DOM.

## Benchmark

```
                         before       after  before(YJIT)  after(YJIT)
                 dom     19.854      23.805        33.969       37.712 i/s -     100.000 times in 5.036779s 4.200839s 2.943877s 2.651709s
                 sax     29.436      30.494        54.070       55.089 i/s -     100.000 times in 3.397155s 3.279348s 1.849463s 1.815255s
                pull     34.908      34.857        62.969       64.895 i/s -     100.000 times in 2.864651s 2.868842s 1.588082s 1.540939s
              stream     34.570      34.281        60.616       60.355 i/s -     100.000 times in 2.892656s 2.917080s 1.649737s 1.656866s

Comparison:
                              dom
         after(YJIT):        37.7 i/s
        before(YJIT):        34.0 i/s - 1.11x  slower
               after:        23.8 i/s - 1.58x  slower
              before:        19.9 i/s - 1.90x  slower

                              sax
         after(YJIT):        55.1 i/s
        before(YJIT):        54.1 i/s - 1.02x  slower
               after:        30.5 i/s - 1.81x  slower
              before:        29.4 i/s - 1.87x  slower

                             pull
         after(YJIT):        64.9 i/s
        before(YJIT):        63.0 i/s - 1.03x  slower
              before:        34.9 i/s - 1.86x  slower
               after:        34.9 i/s - 1.86x  slower

                           stream
        before(YJIT):        60.6 i/s
         after(YJIT):        60.4 i/s - 1.00x  slower
              before:        34.6 i/s - 1.75x  slower
               after:        34.3 i/s - 1.77x  slower
```

- YJIT=ON : 1.00x - 1.11x faster (dom: 1.11x faster)
- YJIT=OFF : 1.00x - 1.20x faster (dom: 1.20x faster)