### PR TITLE
Fix wrong Encoding resolution

### DIFF
--- a/lib/rexml/encoding.rb
+++ b/lib/rexml/encoding.rb
@@ -5,7 +5,7 @@ module REXML
     # ID ---> Encoding name
     attr_reader :encoding
     def encoding=(encoding)
-      encoding = encoding.name if encoding.is_a?(Encoding)
+      encoding = encoding.name if encoding.is_a?(::Encoding)
       if encoding.is_a?(String)
         original_encoding = encoding
         encoding = find_encoding(encoding)

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -1,0 +1,21 @@
+require "rexml/source"
+
+module REXMLTests
+  class TestSource < Test::Unit::TestCase
+    def setup
+      @source = REXML::Source.new(+"<root/>")
+    end
+
+    sub_test_case("#encoding=") do
+      test("String") do
+        @source.encoding = "UTF-8"
+        assert_equal("UTF-8", @source.encoding)
+      end
+
+      test("Encoding") do
+        @source.encoding = Encoding::UTF_8
+        assert_equal("UTF-8", @source.encoding)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this context, `Encoding` means `REXML::Encoding` not `Encoding`.