### PR TITLE
♻️ Remove redundant return statements

### DIFF
--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -202,9 +202,7 @@ module REXML
     end
 
     def xpath
-      path = @element.xpath
-      path += "/@#{self.expanded_name}"
-      return path
+      @element.xpath + "/@#{self.expanded_name}"
     end
 
     def document

--- a/lib/rexml/document.rb
+++ b/lib/rexml/document.rb
@@ -415,7 +415,7 @@ module REXML
     #
     # Deprecated. Use REXML::Security.entity_expansion_limit= instead.
     def Document::entity_expansion_limit
-      return Security.entity_expansion_limit
+      Security.entity_expansion_limit
     end
 
     # Set the entity expansion limit. By default the limit is set to 10240.
@@ -429,7 +429,7 @@ module REXML
     #
     # Deprecated. Use REXML::Security.entity_expansion_text_limit instead.
     def Document::entity_expansion_text_limit
-      return Security.entity_expansion_text_limit
+      Security.entity_expansion_text_limit
     end
 
     attr_reader :entity_expansion_count

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -566,7 +566,7 @@ module REXML
       prefixes = []
       prefixes = parent.prefixes if parent
       prefixes |= attributes.prefixes
-      return prefixes
+      prefixes
     end
 
     # :call-seq:
@@ -625,7 +625,7 @@ module REXML
       ns = namespaces[prefix]
 
       ns = '' if ns.nil? and prefix == 'xmlns'
-      return ns
+      ns
     end
 
     # :call-seq:
@@ -957,7 +957,7 @@ module REXML
     def next_element
       element = next_sibling
       element = element.next_sibling until element.nil? or element.kind_of? Element
-      return element
+      element
     end
 
     # :call-seq:
@@ -973,7 +973,7 @@ module REXML
     def previous_element
       element = previous_sibling
       element = element.previous_sibling until element.nil? or element.kind_of? Element
-      return element
+      element
     end
 
 
@@ -1023,8 +1023,7 @@ module REXML
     #
     def text( path = nil )
       rv = get_text(path)
-      return rv.value unless rv.nil?
-      nil
+      rv&.value
     end
 
     # :call-seq:
@@ -1052,7 +1051,7 @@ module REXML
       else
         rv = @children.find { |node| node.kind_of? Text }
       end
-      return rv
+      rv
     end
 
     # :call-seq:
@@ -1096,7 +1095,7 @@ module REXML
           old_text.replace_with( text )
         end
       end
-      return self
+      self
     end
 
     # :call-seq:
@@ -1147,7 +1146,7 @@ module REXML
         text = Text.new( text, whitespace(), nil, raw() )
       end
       self << text unless text.nil?
-      return self
+      self
     end
 
     # :call-seq:
@@ -1191,7 +1190,7 @@ module REXML
         cur = cur.parent
         path_elements << __to_xpath_helper( cur )
       end
-      return path_elements.reverse.join( "/" )
+      path_elements.reverse.join( "/" )
     end
 
     #################################################
@@ -1293,7 +1292,6 @@ module REXML
       return nil unless ( namespaces[ prefix ] == namespaces[ 'xmlns' ] )
 
       attributes.get_attribute( name )
-
     end
 
     # :call-seq:
@@ -1307,7 +1305,7 @@ module REXML
     #   b.has_attributes? # => false
     #
     def has_attributes?
-      return !@attributes.empty?
+      !@attributes.empty?
     end
 
     # :call-seq:
@@ -1685,11 +1683,7 @@ module REXML
           (num += 1) == index
         }
       else
-        return XPath::first( @element, index )
-        #{ |element|
-        #       return element if element.kind_of? Element
-        #}
-        #return nil
+        XPath::first( @element, index )
       end
     end
 
@@ -1736,7 +1730,7 @@ module REXML
       else
         previous.replace_with element
       end
-      return previous
+      previous
     end
 
     # :call-seq:
@@ -1775,7 +1769,7 @@ module REXML
         child == element
       end
       return rv if found == element
-      return -1
+      -1
     end
 
     # :call-seq:
@@ -1854,7 +1848,7 @@ module REXML
         @element.delete element
         element.remove
       end
-      return rv
+      rv
     end
 
     # :call-seq:
@@ -2181,8 +2175,7 @@ module REXML
     #
     def [](name)
       attr = get_attribute(name)
-      return attr.value unless attr.nil?
-      return nil
+      attr&.value
     end
 
     # :call-seq:
@@ -2337,7 +2330,7 @@ module REXML
       if attr.kind_of? Hash
         attr = attr[ @element.prefix ]
       end
-      return attr
+      attr
     end
 
     # :call-seq:
@@ -2390,7 +2383,7 @@ module REXML
       else
         store value.name, value
       end
-      return @element
+      @element
     end
 
     # :call-seq:
@@ -2492,9 +2485,7 @@ module REXML
           old.each_value{|v| repl = v}
           store name, repl
         end
-      elsif old.nil?
-        return @element
-      else # the supplied attribute is a top-level one
+      elsif old # the supplied attribute is a top-level one
         super(name)
       end
       @element
@@ -2548,7 +2539,7 @@ module REXML
         rv << attribute if attribute.expanded_name == name
       }
       rv.each{ |attr| attr.remove }
-      return rv
+      rv
     end
 
     # :call-seq:

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -39,11 +39,11 @@ module REXML
 
     def Functions::text( )
       if @@context[:node].node_type == :element
-        return @@context[:node].find_all{|n| n.node_type == :text}.collect{|n| n.value}
+        @@context[:node].find_all{|n| n.node_type == :text}.collect{|n| n.value}
       elsif @@context[:node].node_type == :text
-        return @@context[:node].value
+        @@context[:node].value
       else
-        return false
+        false
       end
     end
 

--- a/lib/rexml/namespace.rb
+++ b/lib/rexml/namespace.rb
@@ -42,11 +42,11 @@ module REXML
     # Compares names optionally WITH namespaces
     def has_name?( other, ns=nil )
       if ns
-        return (namespace() == ns and name() == other)
+        namespace() == ns and name() == other
       elsif other.include? ":"
-        return fully_expanded_name == other
+        fully_expanded_name == other
       else
-        return name == other
+        name == other
       end
     end
 
@@ -57,7 +57,7 @@ module REXML
     def fully_expanded_name
       ns = prefix
       return "#{ns}:#@name" if ns.size > 0
-      return @name
+      @name
     end
   end
 end

--- a/lib/rexml/node.rb
+++ b/lib/rexml/node.rb
@@ -68,7 +68,7 @@ module REXML
       each_recursive {|node|
         return node if block.call(node)
       }
-      return nil
+      nil
     end
 
     # Returns the position that +self+ holds in its parent's array, indexed

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -206,12 +206,12 @@ module REXML
 
       # Returns true if there are no more events
       def empty?
-        return (@source.empty? and @stack.empty?)
+        (@source.empty? and @stack.empty?)
       end
 
       # Returns true if there are more events.  Synonymous with !empty?
       def has_next?
-        return !(@source.empty? and @stack.empty?)
+        !(@source.empty? and @stack.empty?)
       end
 
       # Push an event back on the head of the stream.  This method
@@ -522,7 +522,6 @@ module REXML
           raise REXML::ParseException.new( "Exception parsing",
             @source, self, (error ? error : $!) )
         end
-        return [ :dummy ]
       end
       private :pull_event
 

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -522,6 +522,8 @@ module REXML
           raise REXML::ParseException.new( "Exception parsing",
             @source, self, (error ? error : $!) )
         end
+        # NOTE: The end of the method never runs, because it is unreachable.
+        #       All branches of code above have explicit unconditional return or raise statements.
       end
       private :pull_event
 

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -215,7 +215,7 @@ module REXML
         else
           path << yield( parsed )
         end
-        return path.squeeze(" ")
+        path.squeeze(" ")
       end
       # For backward compatibility
       alias_method :preciate_to_string, :predicate_to_path
@@ -252,7 +252,7 @@ module REXML
             path = path[1..-1]
           end
         end
-        return RelativeLocationPath( path, parsed ) if path.size > 0
+        RelativeLocationPath( path, parsed ) if path.size > 0
       end
 
       #RelativeLocationPath
@@ -388,7 +388,7 @@ module REXML
         else
           path = original_path
         end
-        return path
+        path
       end
 
       # Filters the supplied nodeset on the predicate(s)
@@ -600,7 +600,7 @@ module REXML
         end
         rest = LocationPath(rest, n) if rest =~ /\A[\/\.\@\[\w*]/
         parsed.concat(n)
-        return rest
+        rest
       end
 
       #| FilterExpr Predicate

--- a/lib/rexml/quickpath.rb
+++ b/lib/rexml/quickpath.rb
@@ -41,7 +41,7 @@ module REXML
       else
         results = filter([element], path)
       end
-      return results
+      results
     end
 
     # Given an array of nodes it filters the array based on the path. The
@@ -51,18 +51,18 @@ module REXML
       return elements if path.nil? or path == '' or elements.size == 0
       case path
       when /^\/\//u                                                                                     # Descendant
-        return axe( elements, "descendant-or-self", $' )
+        axe( elements, "descendant-or-self", $' )
       when /^\/?\b(\w[-\w]*)\b::/u                                                      # Axe
-        return axe( elements, $1, $' )
+        axe( elements, $1, $' )
       when /^\/(?=\b([:!\w][-\.\w]*:)?[-!\*\.\w]*\b([^:(]|$)|\*)/u      # Child
         rest = $'
         results = []
         elements.each do |element|
           results |= filter( element.to_a, rest )
         end
-        return results
+        results
       when /^\/?(\w[-\w]*)\(/u                                                  # / Function
-        return function( elements, $1, $' )
+        function( elements, $1, $' )
       when Namespace::NAMESPLIT         # Element name
         name = $2
         ns = $1
@@ -73,21 +73,21 @@ module REXML
              (element.name == name and
               element.namespace == Functions.namespace_context[ns])))
         end
-        return filter( elements, rest )
+        filter( elements, rest )
       when /^\/\[/u
         matches = []
         elements.each do |element|
           matches |= predicate( element.to_a, path[1..-1] ) if element.kind_of? Element
         end
-        return matches
+        matches
       when /^\[/u                                                                                               # Predicate
-        return predicate( elements, path )
+        predicate( elements, path )
       when /^\/?\.\.\./u                                                                                # Ancestor
-        return axe( elements, "ancestor", $' )
+        axe( elements, "ancestor", $' )
       when /^\/?\.\./u                                                                                  # Parent
-        return filter( elements.collect{|e|e.parent}, $' )
+        filter( elements.collect{|e|e.parent}, $' )
       when /^\/?\./u                                                                                            # Self
-        return filter( elements, $' )
+        filter( elements, $' )
       when /^\*/u                                                                                                       # Any
         results = []
         elements.each do |element|
@@ -98,9 +98,10 @@ module REXML
           #     results |= filter( children, $' )
           #end
         end
-        return results
+        results
+      else
+        []
       end
-      return []
     end
 
     def QuickPath::axe( elements, axe_name, rest )
@@ -138,7 +139,7 @@ module REXML
         matches = filter(elements.collect{|element|
           element.previous_sibling}.uniq, rest )
       end
-      return matches.uniq
+      matches.uniq
     end
 
     OPERAND_ = '((?=(?:(?!and|or).)*[^\s<>=])[^\s<>=]+)'
@@ -200,15 +201,15 @@ module REXML
           results << element
         end
       end
-      return filter( results, rest )
+      filter( results, rest )
     end
 
     def QuickPath::attribute( name )
-      return Functions.node.attributes[name] if Functions.node.kind_of? Element
+      Functions.node.attributes[name] if Functions.node.kind_of? Element
     end
 
     def QuickPath::name()
-      return Functions.node.name if Functions.node.kind_of? Element
+      Functions.node.name if Functions.node.kind_of? Element
     end
 
     def QuickPath::method_missing( id, *args )
@@ -234,7 +235,7 @@ module REXML
           results << element if Functions.pair[0] == res
         end
       end
-      return results
+      results
     end
 
     def QuickPath::parse_args( element, string )

--- a/lib/rexml/security.rb
+++ b/lib/rexml/security.rb
@@ -10,7 +10,7 @@ module REXML
 
     # Get the entity expansion limit. By default the limit is set to 10000.
     def self.entity_expansion_limit
-      return @@entity_expansion_limit
+      @@entity_expansion_limit
     end
 
     @@entity_expansion_text_limit = 10_240
@@ -22,7 +22,7 @@ module REXML
 
     # Get the entity expansion limit. By default the limit is set to 10240.
     def self.entity_expansion_text_limit
-      return @@entity_expansion_text_limit
+      @@entity_expansion_text_limit
     end
   end
 end

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -177,7 +177,7 @@ module REXML
 
 
     def clone
-      return Text.new(self, true)
+      Text.new(self, true)
     end
 
 
@@ -264,10 +264,10 @@ module REXML
       # Recursively wrap string at width.
       return string if string.length <= width
       place = string.rindex(' ', width) # Position in string with last ' ' before cutoff
-      if addnewline then
-        return "\n" + string[0,place] + "\n" + wrap(string[place+1..-1], width)
+      if addnewline
+        "\n" + string[0,place] + "\n" + wrap(string[place+1..-1], width)
       else
-        return string[0,place] + "\n" + wrap(string[place+1..-1], width)
+        string[0,place] + "\n" + wrap(string[place+1..-1], width)
       end
     end
 
@@ -280,7 +280,7 @@ module REXML
         new_string << new_line
       }
       new_string.strip! unless indentfirstline
-      return new_string
+      new_string
     end
 
     # == DEPRECATED
@@ -299,9 +299,7 @@ module REXML
     # FIXME
     # This probably won't work properly
     def xpath
-      path = @parent.xpath
-      path += "/text()"
-      return path
+      @parent.xpath + "/text()"
     end
 
     # Writes out text, substituting special characters beforehand.

--- a/lib/rexml/validation/relaxng.rb
+++ b/lib/rexml/validation/relaxng.rb
@@ -157,16 +157,16 @@ module REXML
         if ( @events[@current].matches?(event) )
           @current += 1
           if @events[@current].nil?
-            return @previous.pop
+            @previous.pop
           elsif @events[@current].kind_of? State
             @current += 1
             @events[@current-1].previous = self
-            return @events[@current-1]
+            @events[@current-1]
           else
-            return self
+            self
           end
         else
-          return nil
+          nil
         end
       end
 
@@ -186,7 +186,7 @@ module REXML
       end
 
       def expected
-        return [@events[@current]]
+        [@events[@current]]
       end
 
       def <<( event )
@@ -244,7 +244,7 @@ module REXML
             evt = :end_attribute
           end
         end
-        return Event.new( evt, arg )
+        Event.new( evt, arg )
       end
     end
 
@@ -262,9 +262,10 @@ module REXML
           rv = super
           return rv if rv
           @prior = @previous.pop
-          return @prior.next( event )
+          @prior.next( event )
+        else
+          super
         end
-        super
       end
 
       def matches?(event)
@@ -274,7 +275,7 @@ module REXML
 
       def expected
         return [ @prior.expected, @events[0] ].flatten if @current == 0
-        return [@events[@current]]
+        [@events[@current]]
       end
     end
 
@@ -286,24 +287,24 @@ module REXML
           @current += 1
           if @events[@current].nil?
             @current = 0
-            return self
+            self
           elsif @events[@current].kind_of? State
             @current += 1
             @events[@current-1].previous = self
-            return @events[@current-1]
+            @events[@current-1]
           else
-            return self
+            self
           end
         else
           @prior = @previous.pop
           return @prior.next( event ) if @current == 0
-          return nil
+          nil
         end
       end
 
       def expected
         return [ @prior.expected, @events[0] ].flatten if @current == 0
-        return [@events[@current]]
+        [@events[@current]]
       end
     end
 
@@ -326,17 +327,17 @@ module REXML
           @ord += 1
           if @events[@current].nil?
             @current = 0
-            return self
+            self
           elsif @events[@current].kind_of? State
             @current += 1
             @events[@current-1].previous = self
-            return @events[@current-1]
+            @events[@current-1]
           else
-            return self
+            self
           end
         else
           return @previous.pop.next( event ) if @current == 0 and @ord > 0
-          return nil
+          nil
         end
       end
 
@@ -347,9 +348,9 @@ module REXML
 
       def expected
         if @current == 0 and @ord > 0
-          return [@previous[-1].expected, @events[0]].flatten
+          [@previous[-1].expected, @events[0]].flatten
         else
-          return [@events[@current]]
+          [@events[@current]]
         end
       end
     end
@@ -403,7 +404,7 @@ module REXML
 
       def expected
         return [@events[@current]] if @events.size > 0
-        return @choices.collect do |x|
+        @choices.collect do |x|
           if x[0].kind_of? State
             x[0].expected
           else
@@ -490,16 +491,16 @@ module REXML
           @current += 1
           if @events[@current].nil?
             return self unless @choices[@choice].nil?
-            return @previous.pop
+            @previous.pop
           elsif @events[@current].kind_of? State
             @current += 1
             @events[@current-1].previous = self
-            return @events[@current-1]
+            @events[@current-1]
           else
-            return self
+            self
           end
         else
-          return nil
+          nil
         end
       end
 
@@ -510,7 +511,7 @@ module REXML
 
       def expected
         return [@events[@current]] if @events[@current]
-        return @choices[@choice..-1].collect do |x|
+        @choices[@choice..-1].collect do |x|
           if x[0].kind_of? State
             x[0].expected
           else

--- a/lib/rexml/validation/validation.rb
+++ b/lib/rexml/validation/validation.rb
@@ -80,26 +80,26 @@ module REXML
       end
 
       def single?
-        return (@event_type != :start_element and @event_type != :start_attribute)
+        (@event_type != :start_element and @event_type != :start_attribute)
       end
 
       def matches?( event )
         return false unless event[0] == @event_type
         case event[0]
         when nil
-          return true
+          true
         when :start_element
-          return true if event[1] == @event_arg
+          event[1] == @event_arg
         when :end_element
-          return true
+          true
         when :start_attribute
-          return true if event[1] == @event_arg
+          event[1] == @event_arg
         when :end_attribute
-          return true
+          true
         when :end_document
-          return true
+          true
         when :text
-          return (@event_arg.nil? or @event_arg == event[1])
+          @event_arg.nil? || @event_arg == event[1]
 =begin
         when :processing_instruction
           false

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -114,7 +114,7 @@ module REXML
       case path[0]
       when :document
         # do nothing
-        return first( path[1..-1], node )
+        first( path[1..-1], node )
       when :child
         for c in node.children
           r = first( path[1..-1], c )
@@ -124,9 +124,9 @@ module REXML
         name = path[2]
         if node.name == name
           return node if path.size == 3
-          return first( path[3..-1], node )
+          first( path[3..-1], node )
         else
-          return nil
+          nil
         end
       when :descendant_or_self
         r = first( path[1..-1], node )
@@ -136,11 +136,12 @@ module REXML
           return r if r
         end
       when :node
-        return first( path[1..-1], node )
+        first( path[1..-1], node )
       when :any
-        return first( path[1..-1], node )
+        first( path[1..-1], node )
+      else
+        nil
       end
-      return nil
     end
 
 
@@ -167,10 +168,10 @@ module REXML
     #  2. If no mapping was supplied, use the context node to look up the namespace
     def get_namespace( node, prefix )
       if @namespaces
-        return @namespaces[prefix] || ''
+        @namespaces[prefix] || ''
       else
         return node.namespace( prefix ) if node.node_type == :element
-        return ''
+        ''
       end
     end
 
@@ -757,22 +758,19 @@ module REXML
     end
 
     def following_node_of( node )
-      if node.kind_of? Element and node.children.size > 0
-        return node.children[0]
-      end
-      return next_sibling_node(node)
+      return node.children[0] if node.kind_of?(Element) and node.children.size > 0
+
+      next_sibling_node(node)
     end
 
     def next_sibling_node(node)
       psn = node.next_sibling_node
       while psn.nil?
-        if node.parent.nil? or node.parent.class == Document
-          return nil
-        end
+        return nil if node.parent.nil? or node.parent.class == Document
         node = node.parent
         psn = node.next_sibling_node
       end
-      return psn
+      psn
     end
 
     def child(nodeset)
@@ -805,13 +803,13 @@ module REXML
     def norm b
       case b
       when true, false
-        return b
+        b
       when 'true', 'false'
-        return Functions::boolean( b )
+        Functions::boolean( b )
       when /^\d+(\.\d+)?$/, Numeric
-        return Functions::number( b )
+        Functions::number( b )
       else
-        return Functions::string( b )
+        Functions::string( b )
       end
     end
 


### PR DESCRIPTION
Split from #261; expanded and improved.

- [x] Very slight behavior change here in `REXML::Valdiation::Event#matches?` , which is to align the predicate method's return value with the expected behavior of a predicate method (which is to return one of true or false).  See comments for more details.