### PR TITLE
Fix & Deprecate REXML::Text#text_indent

### DIFF
--- a/lib/rexml/child.rb
+++ b/lib/rexml/child.rb
@@ -88,7 +88,7 @@ module REXML
 
     # This doesn't yet handle encodings
     def bytes
-      document.encoding
+      document&.encoding
 
       to_s
     end

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -269,7 +269,7 @@ module REXML
     end
 
     def indent_text(string, level=1, style="\t", indentfirstline=true)
-      Kernel.warn("#{self.class.name}#indent_text is deprecated.  See REXML::Formatters", uplevel: 1)
+      Kernel.warn("#{self.class.name}#indent_text is deprecated. See REXML::Formatters", uplevel: 1)
       return string if level < 0
       new_string = ''
       string.each_line { |line|

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -278,7 +278,7 @@ module REXML
         new_line = (indent_string + line).sub(/[\s]+$/,'')
         new_string << new_line
       }
-      new_string.strip! unless indentfirstline # no change
+      new_string.strip! unless indentfirstline
       new_string
     end
 

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -269,14 +269,15 @@ module REXML
     end
 
     def indent_text(string, level=1, style="\t", indentfirstline=true)
+      Kernel.warn("#{self.class.name}#indent_text is deprecated.  See REXML::Formatters", uplevel: 1)
       return string if level < 0
       new_string = ''
       string.each_line { |line|
         indent_string = style * level
         new_line = (indent_string + line).sub(/[\s]+$/,'')
-        new_string << new_line
+        new_string += new_line
       }
-      new_string.strip! unless indentfirstline
+      new_string = new_string.strip unless indentfirstline
       new_string
     end
 

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -271,13 +271,14 @@ module REXML
     def indent_text(string, level=1, style="\t", indentfirstline=true)
       Kernel.warn("#{self.class.name}#indent_text is deprecated. See REXML::Formatters", uplevel: 1)
       return string if level < 0
-      new_string = ''
+
+      new_string = +''
       string.each_line { |line|
         indent_string = style * level
         new_line = (indent_string + line).sub(/[\s]+$/,'')
-        new_string += new_line
+        new_string << new_line
       }
-      new_string = new_string.strip unless indentfirstline
+      new_string.strip! unless indentfirstline # no change
       new_string
     end
 

--- a/lib/rexml/xpath.rb
+++ b/lib/rexml/xpath.rb
@@ -64,7 +64,7 @@ module REXML
       parser.namespaces = namespaces
       parser.variables = variables
       path = "*" unless path
-      parser.parse(path,element) || []
+      parser.parse(path,element)
     end
   end
 end

--- a/lib/rexml/xpath.rb
+++ b/lib/rexml/xpath.rb
@@ -64,7 +64,7 @@ module REXML
       parser.namespaces = namespaces
       parser.variables = variables
       path = "*" unless path
-      parser.parse(path,element)
+      parser.parse(path,element) || []
     end
   end
 end

--- a/test/test_text.rb
+++ b/test/test_text.rb
@@ -2,6 +2,7 @@
 
 module REXMLTests
   class TextTester < Test::Unit::TestCase
+    include Helper::Global
     include REXML
 
     def test_new_text_response_whitespace_default

--- a/test/test_text.rb
+++ b/test/test_text.rb
@@ -72,7 +72,9 @@ module REXMLTests
 
     def test_indent_text
       text = Text.new("")
-      assert_equal("\tline1\tline2\tline3", text.indent_text("line1\r\nline2\r\nline3\r\n"))
+      suppress_warning do
+        assert_equal("\tline1\tline2\tline3", text.indent_text("line1\r\nline2\r\nline3\r\n"))
+      end
     end
   end
 end

--- a/test/test_text.rb
+++ b/test/test_text.rb
@@ -69,5 +69,10 @@ module REXMLTests
       assert_equal(text.to_s,
                    text.clone.to_s)
     end
+
+    def test_indent_text
+      text = Text.new("")
+      assert_equal("\tline1\tline2\tline3", text.indent_text("line1\r\nline2\r\nline3\r\n"))
+    end
   end
 end


### PR DESCRIPTION
- Fixes #273 
  - "Fix" in the sense that it restores the original behavior pre-v3.2.6, regardless of its fitness for purpose.
- [x] Regression Test Added

Replaces #274