### PR TITLE
Added XML declaration check & `Source#skip_spaces` method

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -280,7 +280,7 @@ module REXML
               return [ :comment, process_comment ]
             elsif @source.match?("DOCTYPE", true)
               base_error_message = "Malformed DOCTYPE"
-              unless @source.match?(/\s+/um, true)
+              unless @source.skip_spaces
                 if @source.match?(">")
                   message = "#{base_error_message}: name is missing"
                 else
@@ -290,7 +290,7 @@ module REXML
                 raise REXML::ParseException.new(message, @source)
               end
               name = parse_name(base_error_message)
-              @source.match?(/\s*/um, true) # skip spaces
+              @source.skip_spaces
               if @source.match?("[", true)
                 id = [nil, nil, nil]
                 @document_status = :in_doctype
@@ -306,7 +306,7 @@ module REXML
                   # For backward compatibility
                   id[1], id[2] = id[2], nil
                 end
-                @source.match?(/\s*/um, true) # skip spaces
+                @source.skip_spaces
                 if @source.match?("[", true)
                   @document_status = :in_doctype
                 elsif @source.match?(">", true)
@@ -319,7 +319,7 @@ module REXML
               end
               args = [:start_doctype, name, *id]
               if @document_status == :after_doctype
-                @source.match?(/\s*/um, true)
+                @source.skip_spaces
                 @stack << [ :end_doctype ]
               end
               return args
@@ -330,7 +330,7 @@ module REXML
           end
         end
         if @document_status == :in_doctype
-          @source.match?(/\s*/um, true) # skip spaces
+          @source.skip_spaces
           start_position = @source.position
           if @source.match?("<!", true)
             if @source.match?("ELEMENT", true)
@@ -391,7 +391,7 @@ module REXML
               return [ :attlistdecl, element, pairs, contents ]
             elsif @source.match?("NOTATION", true)
               base_error_message = "Malformed notation declaration"
-              unless @source.match?(/\s+/um, true)
+              unless @source.skip_spaces
                 if @source.match?(">")
                   message = "#{base_error_message}: name is missing"
                 else
@@ -404,7 +404,7 @@ module REXML
               id = parse_id(base_error_message,
                             accept_external_id: true,
                             accept_public_id: true)
-              @source.match?(/\s*/um, true) # skip spaces
+              @source.skip_spaces
               unless @source.match?(">", true)
                 message = "#{base_error_message}: garbage before end >"
                 raise REXML::ParseException.new(message, @source)
@@ -425,7 +425,7 @@ module REXML
           end
         end
         if @document_status == :after_doctype
-          @source.match?(/\s*/um, true)
+          @source.skip_spaces
         end
         begin
           start_position = @source.position
@@ -735,7 +735,7 @@ module REXML
 
       def process_instruction
         name = parse_name("Malformed XML: Invalid processing instruction node")
-        if @source.match?(/\s+/um, true)
+        if @source.skip_spaces
           match_data = @source.match(/(.*?)\?>/um, true)
           unless match_data
             raise ParseException.new("Malformed XML: Unclosed processing instruction", @source)
@@ -817,7 +817,7 @@ module REXML
               message = "Missing attribute value end quote: <#{name}>: <#{quote}>"
               raise REXML::ParseException.new(message, @source)
             end
-            @source.match?(/\s*/um, true)
+            @source.skip_spaces
             if prefix == "xmlns"
               if local_part == "xml"
                 if value != Private::XML_PREFIXED_NAMESPACE

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -68,7 +68,7 @@ module REXML
       SPACES_PATTERN = /\s+/um
       SCANNER_RESET_SIZE = 100000
       PRE_DEFINED_TERM_PATTERNS = {}
-      pre_defined_terms = ["'", '"', "<", "]]>"]
+      pre_defined_terms = ["'", '"', "<", "]]>", "?>"]
       if StringScanner::Version < "3.1.1"
         pre_defined_terms.each do |term|
           PRE_DEFINED_TERM_PATTERNS[term] = /#{Regexp.escape(term)}/

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -65,6 +65,7 @@ module REXML
     attr_reader :encoding
 
     module Private
+      SPACES_PATTERN = /\s+/um
       SCANNER_RESET_SIZE = 100000
       PRE_DEFINED_TERM_PATTERNS = {}
       pre_defined_terms = ["'", '"', "<", "]]>"]
@@ -148,6 +149,10 @@ module REXML
       else
         !@scanner.match?(pattern).nil?
       end
+    end
+
+    def skip_spaces
+      @scanner.skip(Private::SPACES_PATTERN) ? true : false
     end
 
     def position

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -49,10 +49,10 @@ Last 80 unconsumed characters:
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed DOCTYPE: name is missing
-Line: 3
-Position: 17
+Line: 1
+Position: 10
 Last 80 unconsumed characters:
-<!DOCTYPE>  <r/> 
+<!DOCTYPE>
         DETAIL
       end
     end

--- a/test/test_xml_declaration.rb
+++ b/test/test_xml_declaration.rb
@@ -7,7 +7,7 @@ module REXMLTests
   class TestXmlDeclaration < Test::Unit::TestCase
     def setup
       xml = <<~XML
-      <?xml encoding= 'UTF-8' standalone='yes'?>
+      <?xml version='1.0' encoding= 'UTF-8' standalone='yes'?>
       <root>
       </root>
       XML


### PR DESCRIPTION
## Why?

### Added XML declaration check

- The version attribute is required in XML declaration.
- Only version attribute, encoding attribute, and standalone attribute are allowed in XML declaration.
- XML declaration is only allowed once.

See: https://www.w3.org/TR/xml/#NT-XMLDecl

### Added `Source#skip_spaces` method

In the case of `@source.match?(/\s+/um, true)`, if there are no spaces at the beginning, I want to stop reading immediately.
However, it continues to read the buffer until it finds a match, but it never finds a match.
As a result, it continues reading until the end of the file.

In the case of large XML files, drop_parsed_content occur frequently until the buffer is cleared, which may affect performance.


## Benchmark

```
                         before       after  before(YJIT)  after(YJIT) 
                 dom     32.534      35.130        54.559       53.528 i/s -     100.000 times in 3.073715s 2.846540s 1.832883s 1.868189s
                 sax     44.785      44.089        78.303       77.842 i/s -     100.000 times in 2.232907s 2.268138s 1.277093s 1.284657s
                pull     51.750      51.105        90.819       90.658 i/s -     100.000 times in 1.932351s 1.956759s 1.101094s 1.103050s
              stream     51.427      51.444        89.820       88.971 i/s -     100.000 times in 1.944502s 1.943855s 1.113340s 1.123960s

Comparison:
                              dom
        before(YJIT):        54.6 i/s 
         after(YJIT):        53.5 i/s - 1.02x  slower
               after:        35.1 i/s - 1.55x  slower
              before:        32.5 i/s - 1.68x  slower

                              sax
        before(YJIT):        78.3 i/s 
         after(YJIT):        77.8 i/s - 1.01x  slower
              before:        44.8 i/s - 1.75x  slower
               after:        44.1 i/s - 1.78x  slower

                             pull
        before(YJIT):        90.8 i/s 
         after(YJIT):        90.7 i/s - 1.00x  slower
              before:        51.8 i/s - 1.75x  slower
               after:        51.1 i/s - 1.78x  slower

                           stream
        before(YJIT):        89.8 i/s 
         after(YJIT):        89.0 i/s - 1.01x  slower
               after:        51.4 i/s - 1.75x  slower
              before:        51.4 i/s - 1.75x  slower
```

- YJIT=ON : 0.98x - 1.00x faster
- YJIT=OFF : 0.98x - 1.07x faster