### PR TITLE
Reject no root element XML as an invalid XML

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -266,6 +266,11 @@ module REXML
             path = "/" + @tags.join("/")
             raise ParseException.new("Missing end tag for '#{path}'", @source)
           end
+
+          unless @document_status == :in_element
+            raise ParseException.new("Malformed XML: No root element", @source)
+          end
+
           return [ :end_document ]
         end
         return @stack.shift if @stack.size > 0

--- a/test/parse/test_attribute_list_declaration.rb
+++ b/test/parse/test_attribute_list_declaration.rb
@@ -10,9 +10,9 @@ module REXMLTests
     def test_linear_performance_space
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new("<!DOCTYPE schema SYSTEM \"foo.dtd\" [<!ATTLIST " +
+        REXML::Document.new("<!DOCTYPE root SYSTEM \"foo.dtd\" [<!ATTLIST " +
                             " " * n +
-                            " root v CDATA #FIXED \"test\">]>")
+                            " root v CDATA #FIXED \"test\">]><root/>")
       end
     end
 
@@ -23,7 +23,7 @@ module REXMLTests
                             "\t" * n +
                             "root value CDATA \"" +
                             ">" * n +
-                            "\">]>")
+                            "\">]><root/>")
       end
     end
   end

--- a/test/parse/test_comment.rb
+++ b/test/parse/test_comment.rb
@@ -174,7 +174,7 @@ module REXMLTests
     def test_linear_performance_top_level_gt
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new('<!-- ' + ">" * n + ' -->')
+        REXML::Document.new('<!-- ' + ">" * n + ' --><a/>')
       end
     end
 

--- a/test/parse/test_element.rb
+++ b/test/parse/test_element.rb
@@ -12,6 +12,45 @@ module REXMLTests
     end
 
     class TestInvalid < self
+      def test_top_level_no_tag
+        exception = assert_raise(REXML::ParseException) do
+          parse("")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed XML: No root element
+Line: 0
+Position: 0
+Last 80 unconsumed characters:
+
+        DETAIL
+      end
+
+      def test_top_level_no_tag_with_xml_declaration
+        exception = assert_raise(REXML::ParseException) do
+          parse("<?xml version='1.0'?>")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed XML: No root element
+Line: 1
+Position: 21
+Last 80 unconsumed characters:
+
+        DETAIL
+      end
+
+      def test_top_level_no_tag_with_comment
+        exception = assert_raise(REXML::ParseException) do
+          parse("<!-- comment -->")
+        end
+        assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed XML: No root element
+Line: 1
+Position: 16
+Last 80 unconsumed characters:
+
+        DETAIL
+      end
+
       def test_top_level_end_tag
         exception = assert_raise(REXML::ParseException) do
           parse("</a>")

--- a/test/parse/test_entity_declaration.rb
+++ b/test/parse/test_entity_declaration.rb
@@ -523,7 +523,7 @@ Last 80 unconsumed characters:
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new("<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version \"" +
                             ">" * n +
-                            "\">]>")
+                            "\">]><rubynet/>")
       end
     end
 
@@ -532,7 +532,7 @@ Last 80 unconsumed characters:
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new("<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version \"" +
                             ">]" * n +
-                            "\">]>")
+                            "\">]><rubynet/>")
       end
     end
 
@@ -541,7 +541,7 @@ Last 80 unconsumed characters:
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new("<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version SYSTEM \"" +
                             ">]" * n +
-                            "\">]>")
+                            "\">]><rubynet/>")
       end
     end
 
@@ -550,7 +550,7 @@ Last 80 unconsumed characters:
       assert_linear_performance(seq, rehearsal: 10) do |n|
         REXML::Document.new("<!DOCTYPE rubynet [<!ENTITY rbconfig.ruby_version PUBLIC \"pubid-literal\" \"" +
                             ">]" * n +
-                            "\">]>")
+                            "\">]><rubynet/>")
       end
     end
   end

--- a/test/parse/test_processing_instruction.rb
+++ b/test/parse/test_processing_instruction.rb
@@ -237,14 +237,14 @@ Last 80 unconsumed characters:
     def test_linear_performance_gt
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new("<?name content " + ">" * n + " ?>")
+        REXML::Document.new("<?name content " + ">" * n + " ?><a/>")
       end
     end
 
     def test_linear_performance_tab
       seq = [10000, 50000, 100000, 150000, 200000]
       assert_linear_performance(seq, rehearsal: 10) do |n|
-        REXML::Document.new("<?name" + "\t" * n + "version=\"1.0\" > ?>")
+        REXML::Document.new("<?name" + "\t" * n + "version=\"1.0\" > ?><a/>")
       end
     end
   end

--- a/test/test_contrib.rb
+++ b/test/test_contrib.rb
@@ -472,7 +472,7 @@ EOL
 <!ENTITY % extern-packages SYSTEM "../../common-declarations.dtd">
 %extern-packages;
 %extern-common;
-]>}
+]><ivattacks/>}
       doc = Document.new( src )
       doc.write( out="" )
       src = src.tr('"', "'")

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -329,7 +329,7 @@ Last 80 unconsumed characters:
       REXML::Formatters::Default.new.write( instruction, out = "" )
       assert_equal(source, out)
 
-      d = Document.new( source )
+      d = Document.new( source + "<a/>")
       instruction2 = d[0]
       assert_equal(instruction.to_s, instruction2.to_s)
 
@@ -875,7 +875,7 @@ EOL
     def test_element_decl
       element_decl = Source.new("<!DOCTYPE foo [
 <!ELEMENT bar (#PCDATA)>
-]>")
+]><foo/>")
       doc = Document.new( element_decl )
       d = doc[0]
       assert_equal("<!ELEMENT bar (#PCDATA)>", d.to_s.split(/\n/)[1].strip)
@@ -1329,7 +1329,7 @@ EOL
     end
 
     def test_ticket_52
-      source = "<!-- this is a single line comment -->"
+      source = "<!-- this is a single line comment --><a/>"
       d = REXML::Document.new(source)
       d.write(k="")
       assert_equal( source, k )
@@ -1408,10 +1408,10 @@ value/>
     end
 
     def test_ticket_88
-      doc = REXML::Document.new("<?xml version=\"1.0\" encoding=\"shift_jis\"?>")
-      assert_equal("<?xml version='1.0' encoding='SHIFT_JIS'?>", doc.to_s)
-      doc = REXML::Document.new("<?xml version = \"1.0\" encoding = \"shift_jis\"?>")
-      assert_equal("<?xml version='1.0' encoding='SHIFT_JIS'?>", doc.to_s)
+      doc = REXML::Document.new("<?xml version=\"1.0\" encoding=\"shift_jis\"?><a/>")
+      assert_equal("<?xml version='1.0' encoding='SHIFT_JIS'?><a/>", doc.to_s)
+      doc = REXML::Document.new("<?xml version = \"1.0\" encoding = \"shift_jis\"?><a/>")
+      assert_equal("<?xml version='1.0' encoding='SHIFT_JIS'?><a/>", doc.to_s)
     end
 
     def test_ticket_85
@@ -1548,10 +1548,6 @@ ENDXML
                    doc.root.attributes.to_h)
       assert_equal(expected,
                    REXML::Document.new(doc.root.to_s).root.attributes.to_h)
-    end
-
-    def test_empty_doc
-      assert(REXML::Document.new('').children.empty?)
     end
 
     private

--- a/test/test_document.rb
+++ b/test/test_document.rb
@@ -151,11 +151,11 @@ EOX
 
     def test_xml_declaration_standalone
       bug2539 = '[ruby-core:27345]'
-      doc = REXML::Document.new('<?xml version="1.0" standalone="no" ?>')
+      doc = REXML::Document.new('<?xml version="1.0" standalone="no" ?><a/>')
       assert_equal('no', doc.stand_alone?, bug2539)
-      doc = REXML::Document.new('<?xml version="1.0" standalone= "no" ?>')
+      doc = REXML::Document.new('<?xml version="1.0" standalone= "no" ?><a/>')
       assert_equal('no', doc.stand_alone?, bug2539)
-      doc = REXML::Document.new('<?xml version="1.0" standalone=  "no" ?>')
+      doc = REXML::Document.new('<?xml version="1.0" standalone=  "no" ?><a/>')
       assert_equal('no', doc.stand_alone?, bug2539)
     end
 

--- a/test/test_entity.rb
+++ b/test/test_entity.rb
@@ -79,7 +79,7 @@ module REXMLTests
         <!ENTITY hatch-pic
                 SYSTEM "../grafix/OpenHatch.gif"
                 NDATA gif>
-      ]>}
+      ]><foo/>}
 
       d = REXML::Document.new( source )
       dt = d.doctype


### PR DESCRIPTION
## Why?

GitHub: fix https://github.com/ruby/rexml/issues/289

We must reject all well-formed XMLs:

https://www.w3.org/TR/2006/REC-xml11-20060816/#proc-types

> Validating and non-validating processors alike MUST report violations of this specification's well-formedness constraints in the content of the [document entity](https://www.w3.org/TR/2006/REC-xml11-20060816/#dt-docent) and any other [parsed entities](https://www.w3.org/TR/2006/REC-xml11-20060816/#dt-parsedent) that they read.

No root element XML is not well-formed because `document` requires one `element`:

https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-well-formed

> [1]   	document	   ::=   	( [prolog](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-prolog) [element](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-element) [Misc](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Misc)* ) - ( [Char](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Char)* [RestrictedChar](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-RestrictedChar) [Char](https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Char)* )

