### PR TITLE
The Zlib::GzipReader in JRuby does not behave as expected with REXML, so the test is skipped

### DIFF
--- a/test/test_order.rb
+++ b/test/test_order.rb
@@ -47,6 +47,8 @@ END
      end
      # Provided by Tom Talbott
      def test_more_ordering
+       omit("not supported on JRuby") if RUBY_ENGINE == "jruby"
+
        doc = Zlib::GzipReader.open(fixture_path('LostineRiver.kml.gz'), encoding: 'utf-8') do |f|
          REXML::Document.new(f)
        end
@@ -104,6 +106,8 @@ END
          assert_equal( actual[count], n ) unless n =~ /Arrive at/
          count += 1
        }
+
+       assert_equal( actual.size, count )
      end if defined?(Zlib::GzipReader)
   end
 end


### PR DESCRIPTION
## Why?

JRuby's `Zlib::GzipReader#readline` does not support arguments, so when using `Zlib::GzipReader.open`, it always returns an empty string and does not function. We will temporarily exclude `Zlib::GzipReader` from test coverage.

```
$ test/run.rb --location test/test_order.rb:49

Failure: test_more_ordering(REXMLTests::OrderTester)
/Users/naitoh/ghq/github.com/naitoh/rexml/test/test_order.rb:110:in `test_more_ordering'
     107:          count += 1
     108:        }
     109:
  => 110:        assert_equal( actual.size, count )
     111:      end if defined?(Zlib::GzipReader)
     112:   end
     113: end
<46> expected but was
<0>
```

See: https://github.com/jruby/jruby/issues/8997