### PR TITLE
Use more StringScanner based API for parse_id

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -696,36 +696,35 @@ module REXML
 
       def parse_id_invalid_details(accept_external_id:,
                                    accept_public_id:)
-        public = /\A\s*PUBLIC/um
-        system = /\A\s*SYSTEM/um
-        if (accept_external_id or accept_public_id) and @source.match?(/#{public}/um)
-          if @source.match?(/#{public}(?:\s+[^'"]|\s*[\[>])/um)
+        @source.skip_spaces
+        if (accept_external_id or accept_public_id) and @source.match?("PUBLIC", true)
+          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
             return "public ID literal is missing"
           end
-          unless @source.match?(/#{public}\s+#{PUBIDLITERAL}/um)
+          unless @source.match?(/\s+#{PUBIDLITERAL}/um)
             return "invalid public ID literal"
           end
           if accept_public_id
-            if @source.match?(/#{public}\s+#{PUBIDLITERAL}\s+[^'"]/um)
+            if @source.match?(/\s+#{PUBIDLITERAL}\s+[^'"]/um)
               return "system ID literal is missing"
             end
-            unless @source.match?(/#{public}\s+#{PUBIDLITERAL}\s+#{SYSTEMLITERAL}/um)
+            unless @source.match?(/\s+#{PUBIDLITERAL}\s+#{SYSTEMLITERAL}/um)
               return "invalid system literal"
             end
             "garbage after system literal"
           else
             "garbage after public ID literal"
           end
-        elsif accept_external_id and @source.match?(/#{system}/um)
-          if @source.match?(/#{system}(?:\s+[^'"]|\s*[\[>])/um)
+        elsif accept_external_id and @source.match?("SYSTEM", true)
+          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
             return "system literal is missing"
           end
-          unless @source.match?(/#{system}\s+#{SYSTEMLITERAL}/um)
+          unless @source.match?(/\s+#{SYSTEMLITERAL}/um)
             return "invalid system literal"
           end
           "garbage after system literal"
         else
-          unless @source.match?(/\A\s*(?:PUBLIC|SYSTEM)\s/um)
+          unless @source.match?(/(?:PUBLIC|SYSTEM)\s/um)
             return "invalid ID type"
           end
           "ID type is missing"

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -684,7 +684,7 @@ module REXML
             pubid = pubid_literal[1..-2] if pubid_literal # Remove quote
             return ["PUBLIC", pubid, nil]
           end
-          details = parse_id_invalid_details_public(accept_public_id: accept_public_id)
+          details = parse_id_invalid_details_public
         elsif @source.match?("SYSTEM", true)
           if (md = @source.match(Private::EXTERNAL_ID_SYSTEM_PATTERN, true))
             system = nil
@@ -704,24 +704,14 @@ module REXML
         raise REXML::ParseException.new(message, @source)
       end
 
-      def parse_id_invalid_details_public(accept_public_id:)
+      def parse_id_invalid_details_public
         if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
           return "public ID literal is missing"
         end
         unless @source.match?(Private::PUBLIC_ID_PATTERN)
           return "invalid public ID literal"
         end
-        if accept_public_id
-          if @source.match?(/\s+#{PUBIDLITERAL}\s+[^'"]/um)
-            return "system ID literal is missing"
-          end
-          unless @source.match?(Private::EXTERNAL_ID_PUBLIC_PATTERN)
-            return "invalid system literal"
-          end
-          return "garbage after system literal"
-        else
-          return "garbage after public ID literal"
-        end
+        return "garbage after public ID literal"
       end
 
       def process_comment

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -684,7 +684,13 @@ module REXML
             pubid = pubid_literal[1..-2] if pubid_literal # Remove quote
             return ["PUBLIC", pubid, nil]
           end
-          details = parse_id_invalid_details_public
+          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
+            details = "public ID literal is missing"
+          elsif !@source.match?(Private::PUBLIC_ID_PATTERN)
+            details = "invalid public ID literal"
+          else
+            details = "garbage after public ID literal"
+          end
         elsif @source.match?("SYSTEM", true)
           if (md = @source.match(Private::EXTERNAL_ID_SYSTEM_PATTERN, true))
             system = nil
@@ -702,16 +708,6 @@ module REXML
         end
         message = "#{base_error_message}: #{details}"
         raise REXML::ParseException.new(message, @source)
-      end
-
-      def parse_id_invalid_details_public
-        if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
-          return "public ID literal is missing"
-        end
-        unless @source.match?(Private::PUBLIC_ID_PATTERN)
-          return "invalid public ID literal"
-        end
-        return "garbage after public ID literal"
       end
 
       def process_comment

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -692,7 +692,11 @@ module REXML
             system = system_literal[1..-2] if system_literal # Remove quote
             return ["SYSTEM", nil, system]
           end
-          details = parse_id_invalid_details_system
+          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
+            details = "system literal is missing"
+          else
+            details = "invalid system literal"
+          end
         else
           details = "invalid ID type"
         end
@@ -718,13 +722,6 @@ module REXML
         else
           return "garbage after public ID literal"
         end
-      end
-
-      def parse_id_invalid_details_system
-        if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
-          return "system literal is missing"
-        end
-        return "invalid system literal"
       end
 
       def process_comment

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -677,37 +677,33 @@ module REXML
             pubid = pubid_literal[1..-2] if pubid_literal # Remove quote
             system_literal = md[2]
             system = system_literal[1..-2] if system_literal # Remove quote
-            return ["PUBLIC", pubid, system]
+            ["PUBLIC", pubid, system]
           elsif accept_public_id and (md = @source.match(Private::PUBLIC_ID_PATTERN, true))
             pubid = system = nil
             pubid_literal = md[1]
             pubid = pubid_literal[1..-2] if pubid_literal # Remove quote
-            return ["PUBLIC", pubid, nil]
-          end
-          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
-            details = "public ID literal is missing"
+            ["PUBLIC", pubid, nil]
+          elsif @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
+            raise REXML::ParseException.new("#{base_error_message}: public ID literal is missing", @source)
           elsif !@source.match?(Private::PUBLIC_ID_PATTERN)
-            details = "invalid public ID literal"
+            raise REXML::ParseException.new("#{base_error_message}: invalid public ID literal", @source)
           else
-            details = "garbage after public ID literal"
+            raise REXML::ParseException.new("#{base_error_message}: garbage after public ID literal", @source)
           end
         elsif @source.match?("SYSTEM", true)
           if (md = @source.match(Private::EXTERNAL_ID_SYSTEM_PATTERN, true))
             system = nil
             system_literal = md[1]
             system = system_literal[1..-2] if system_literal # Remove quote
-            return ["SYSTEM", nil, system]
-          end
-          if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
-            details = "system literal is missing"
+            ["SYSTEM", nil, system]
+          elsif @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
+            raise REXML::ParseException.new("#{base_error_message}: system literal is missing", @source)
           else
-            details = "invalid system literal"
+            raise REXML::ParseException.new("#{base_error_message}: invalid system literal", @source)
           end
         else
-          details = "invalid ID type"
+          raise REXML::ParseException.new("#{base_error_message}: invalid ID type", @source)
         end
-        message = "#{base_error_message}: #{details}"
-        raise REXML::ParseException.new(message, @source)
       end
 
       def process_comment

--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -733,10 +733,7 @@ module REXML
           if @source.match?(/(?:\s+[^'"]|\s*[\[>])/um)
             return "system literal is missing"
           end
-          unless @source.match?(Private::EXTERNAL_ID_SYSTEM_PATTERN)
-            return "invalid system literal"
-          end
-          return "garbage after system literal"
+          return "invalid system literal"
         end
         "ID type is missing"
       end

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -165,10 +165,10 @@ Last 80 unconsumed characters:
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed DOCTYPE: garbage after external ID
-Line: 3
-Position: 36
+Line: 1
+Position: 29
 Last 80 unconsumed characters:
-x'>  <r/> 
+x'>
           DETAIL
         end
 

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -235,6 +235,21 @@ Last 80 unconsumed characters:
         end
 
         class TestSystemLiteral < self
+          def test_garbage_after_public_ID_literal
+            exception = assert_raise(REXML::ParseException) do
+              parse(<<-DOCTYPE)
+<!DOCTYPE r PUBLIC "public-id-literal" 'system>
+              DOCTYPE
+            end
+            assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: garbage after public ID literal
+Line: 3
+Position: 54
+Last 80 unconsumed characters:
+ "public-id-literal" 'system>  <r/> 
+            DETAIL
+          end
+
           def test_garbage_after_literal
             exception = assert_raise(REXML::ParseException) do
               parse(<<-DOCTYPE)

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -157,6 +157,21 @@ Last 80 unconsumed characters:
           DETAIL
         end
 
+        def test_garbage_invalid_system_literal
+          exception = assert_raise(REXML::ParseException) do
+            parse(<<-DOCTYPE)
+<!DOCTYPE r SYSTEM '
+            DOCTYPE
+          end
+          assert_equal(<<-DETAIL.chomp, exception.to_s)
+Malformed DOCTYPE: invalid system literal
+Line: 3
+Position: 27
+Last 80 unconsumed characters:
+ '  <r/> 
+          DETAIL
+        end
+
         def test_garbage_after_literal
           exception = assert_raise(REXML::ParseException) do
             parse(<<-DOCTYPE)

--- a/test/parse/test_document_type_declaration.rb
+++ b/test/parse/test_document_type_declaration.rb
@@ -153,7 +153,7 @@ Malformed DOCTYPE: system literal is missing
 Line: 3
 Position: 26
 Last 80 unconsumed characters:
-SYSTEM>  <r/> 
+>  <r/> 
           DETAIL
         end
 
@@ -200,7 +200,7 @@ Malformed DOCTYPE: invalid public ID literal
 Line: 3
 Position: 62
 Last 80 unconsumed characters:
-PUBLIC 'double quote " is invalid' "r.dtd">  <r/> 
+ 'double quote " is invalid' "r.dtd">  <r/> 
             DETAIL
           end
 

--- a/test/parse/test_notation_declaration.rb
+++ b/test/parse/test_notation_declaration.rb
@@ -80,7 +80,7 @@ Malformed notation declaration: invalid ID type
 Line: 5
 Position: 85
 Last 80 unconsumed characters:
- INVALID>  ]> <r/> 
+INVALID>  ]> <r/> 
         DETAIL
       end
     end
@@ -98,7 +98,7 @@ Malformed notation declaration: system literal is missing
 Line: 5
 Position: 84
 Last 80 unconsumed characters:
- SYSTEM>  ]> <r/> 
+>  ]> <r/> 
           DETAIL
         end
 
@@ -145,7 +145,7 @@ Malformed notation declaration: invalid public ID literal
 Line: 5
 Position: 129
 Last 80 unconsumed characters:
- PUBLIC 'double quote " is invalid' "system-literal">  ]> <r/> 
+ 'double quote " is invalid' "system-literal">  ]> <r/> 
             DETAIL
           end
 
@@ -229,7 +229,7 @@ Malformed notation declaration: public ID literal is missing
 Line: 5
 Position: 84
 Last 80 unconsumed characters:
- PUBLIC>  ]> <r/> 
+>  ]> <r/> 
         DETAIL
       end
 
@@ -244,7 +244,7 @@ Malformed notation declaration: invalid public ID literal
 Line: 5
 Position: 128
 Last 80 unconsumed characters:
- PUBLIC 'double quote \" is invalid in PubidLiteral'>  ]> <r/> 
+ 'double quote \" is invalid in PubidLiteral'>  ]> <r/> 
         DETAIL
       end
 

--- a/test/parse/test_notation_declaration.rb
+++ b/test/parse/test_notation_declaration.rb
@@ -32,10 +32,10 @@ module REXMLTests
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed notation declaration: name is missing
-Line: 5
-Position: 72
+Line: 2
+Position: 62
 Last 80 unconsumed characters:
-<!NOTATION>  ]> <r/> 
+<!NOTATION>
         DETAIL
       end
 
@@ -62,10 +62,10 @@ Last 80 unconsumed characters:
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed notation declaration: invalid ID type
-Line: 5
-Position: 77
+Line: 2
+Position: 67
 Last 80 unconsumed characters:
->  ]> <r/> 
+>
         DETAIL
       end
 
@@ -77,10 +77,10 @@ Last 80 unconsumed characters:
         end
         assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed notation declaration: invalid ID type
-Line: 5
-Position: 85
+Line: 2
+Position: 75
 Last 80 unconsumed characters:
-INVALID>  ]> <r/> 
+INVALID>
         DETAIL
       end
     end
@@ -110,10 +110,10 @@ Last 80 unconsumed characters:
           end
           assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed notation declaration: garbage before end >
-Line: 5
-Position: 103
+Line: 2
+Position: 93
 Last 80 unconsumed characters:
-x'>  ]> <r/> 
+x'>
           DETAIL
         end
 
@@ -173,10 +173,10 @@ Last 80 unconsumed characters:
             end
             assert_equal(<<-DETAIL.chomp, exception.to_s)
 Malformed notation declaration: garbage before end >
-Line: 5
-Position: 123
+Line: 2
+Position: 113
 Last 80 unconsumed characters:
-x'>  ]> <r/> 
+x'>
            DETAIL
           end
 


### PR DESCRIPTION
## Why?

Improve maintainability by optimizing the process so that the parsing process proceeds using StringScanner.