### PR TITLE
Fixed an issue when executing `REXML::Parsers::SAX2Parser#parse` without specifying `#listen`

### DIFF
--- a/lib/rexml/parsers/sax2parser.rb
+++ b/lib/rexml/parsers/sax2parser.rb
@@ -157,7 +157,7 @@ module REXML
               ob.end_element( uri, local, event[1] )
             } if listeners
 
-            namespace_mapping = @namespace_stack.pop
+            namespace_mapping = @namespace_stack.pop if procs or listeners
             # find the observers for namespaces
             procs = get_procs( :end_prefix_mapping, event[1] )
             listeners = get_listeners( :end_prefix_mapping, event[1] )

--- a/test/test_sax.rb
+++ b/test/test_sax.rb
@@ -7,6 +7,12 @@ module REXMLTests
   class SAX2Tester < Test::Unit::TestCase
     include Helper::Fixture
     include REXML
+
+    def test_without_listien
+      p = Parsers::SAX2Parser.new "<a><a></a></a>"
+      p.parse
+    end
+
     def test_characters
       d = Document.new( "<A>@blah@</A>" )
       txt = d.root.text


### PR DESCRIPTION
## Why?

```
> require 'rexml/parsers/sax2parser'
> REXML::Parsers::SAX2Parser.new("<a><b></b></a>").parse
lib/rexml/parsers/sax2parser.rb:263:in 'REXML::Parsers::SAX2Parser#get_namespace': undefined method '[]' for nil (NoMethodError)

        current_namespace[prefix] || current_namespace[nil]
                         ^^^^^^^^
	from lib/rexml/parsers/sax2parser.rb:150:in 'REXML::Parsers::SAX2Parser#parse'
```