### PR TITLE
Optimization of REXML::Parsers::SAX2Parser#get_procs, #get_listeners

### DIFF
--- a/lib/rexml/parsers/sax2parser.rb
+++ b/lib/rexml/parsers/sax2parser.rb
@@ -226,12 +226,8 @@ module REXML
         return nil if @procs.size == 0
         @procs.find_all do |sym, match, block|
           (
-            (sym.nil? or symbol == sym) and
-            ((name.nil? and match.nil?) or match.nil? or (
-              (name == match) or
-              (match.kind_of? Regexp and name =~ match)
-              )
-            )
+            (sym.nil? or (symbol == sym)) and
+            (match.nil? or (name == match) or (match.kind_of? Regexp and match.match?(name)))
           )
         end.collect{|x| x[-1]}
       end
@@ -239,12 +235,8 @@ module REXML
         return nil if @listeners.size == 0
         @listeners.find_all do |sym, match, block|
           (
-            (sym.nil? or symbol == sym) and
-            ((name.nil? and match.nil?) or match.nil? or (
-              (name == match) or
-              (match.kind_of? Regexp and name =~ match)
-              )
-            )
+            (sym.nil? or (symbol == sym)) and
+            (match.nil? or (name == match) or (match.kind_of? Regexp and match.match?(name)))
           )
         end.collect{|x| x[-1]}
       end


### PR DESCRIPTION
## Benchmark
```
$ benchmark-driver benchmark/sax.yaml
                         before       after  before(YJIT)  after(YJIT)
                 sax     2.309k      2.317k        2.760k       2.879k i/s -     100.000 times in 0.043300s 0.043155s 0.036238s 0.034738s

Comparison:
                              sax
         after(YJIT):      2878.7 i/s
        before(YJIT):      2759.5 i/s - 1.04x  slower
               after:      2317.2 i/s - 1.24x  slower
              before:      2309.5 i/s - 1.25x  slower
```
- YJIT=ON : 1.04x faster
- YJIT=OFF : 1.00x faster