### PR TITLE
Optimization of REXML::XPathParser#step

### DIFF
--- a/benchmark/xpath.yaml
+++ b/benchmark/xpath.yaml
@@ -24,9 +24,10 @@ contexts:
 prelude: |
   require 'rexml/document'
 
-  DEPTH = 100
+  DEPTH = 30
   xml   = '<a>' * DEPTH + '</a>' * DEPTH
   doc   = REXML::Document.new(xml)
 
 benchmark:
   "REXML::XPath.match(REXML::Document.new(xml), 'a//a')" : REXML::XPath.match(doc, "a//a")
+  "REXML::XPath.match(REXML::Document.new(xml), '//a//a')" : REXML::XPath.match(doc, "//a//a")

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -462,21 +462,20 @@ module REXML
         if nodesets.size == 1
           ordered_nodeset = nodesets[0]
         else
+          seen = {}.compare_by_identity
           raw_nodes = []
           nodesets.each do |nodeset|
             nodeset.each do |node|
-              if node.respond_to?(:raw_node)
-                raw_nodes << node.raw_node
-              else
-                raw_nodes << node
-              end
+              raw_node = node.respond_to?(:raw_node) ? node.raw_node : node
+              next if seen.key?(raw_node)
+              seen[raw_node] = true
+              raw_nodes << raw_node
             end
           end
           ordered_nodeset = sort(raw_nodes, order)
         end
         new_nodeset = []
         ordered_nodeset.each do |node|
-          # TODO: Remove duplicated
           new_nodeset << XPathNode.new(node, position: new_nodeset.size + 1)
         end
         new_nodeset

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1306,5 +1306,79 @@ EOF
       result = XPath.match(xmldoc, "//a//a")
       assert_equal(["1", "2", "3"], result.map { |e| e.attributes["id"] })
     end
+
+    def test_descendant_ancestor_descendant_overlap
+      doc = <<-XML
+      <root>
+        <a id='1'>
+          <a id='2'>
+            <b id='b1'/>
+          </a>
+        </a>
+      </root>
+      XML
+
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a//b")
+      assert_equal(["b1"], result.map { |e| e.attributes["id"] })
+    end
+
+    def test_descendant_sibling_branches
+      doc = <<-XML
+      <root>
+        <a id='1'>
+          <b id='b1'/>
+        </a>
+        <a id='2'>
+          <b id='b2'/>
+        </a>
+      </root>
+      XML
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a//b")
+      assert_equal(["b1", "b2"], result.map { |e| e.attributes["id"] })
+    end
+
+    def test_descendant_document_order_with_shared_subtree
+      doc = <<-XML
+      <root>
+        <a>
+          <b id='b1'/>
+          <a>
+            <b id='b2'/>
+          </a>
+        </a>
+      </root>
+      XML
+
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a//b")
+      assert_equal(["b1", "b2"], result.map { |e| e.attributes["id"] })
+    end
+
+    def test_descendant_axis_on_leaf_element
+      doc = Document.new("<root><b/></root>")
+      result = XPath.match(doc, "//b/descendant::node()")
+      assert_equal([], result)
+    end
+
+    def test_descendant_axis_position_predicate_per_context_node
+      doc = <<-XML
+      <a id="a1">
+        <b id="b1">
+          <a id="a2">
+            <b id="b2">
+              <b id="b3">
+              </b>
+            </b>
+          </a>
+        </b>
+      </a>
+      XML
+
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a/descendant::b[1]")
+      assert_equal(["b1", "b2"], result.map { |e| e.attributes["id"] })
+    end
   end
 end

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1276,5 +1276,35 @@ EOF
     ensure
       $VERBOSE = verbose
     end
+
+    def test_descendant_no_duplicates
+      doc = <<-XML
+      <a>
+        <a id='1'>
+          <a id='2'/>
+        </a>
+        <a id='3'/>
+      </a>
+      XML
+
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a//a")
+      assert_equal(["1", "2", "3"], result.map { |e| e.attributes["id"] })
+    end
+
+    def test_descendant_document_order
+      doc = <<-XML
+      <a>
+        <a id='1'>
+          <a id='2'>
+            <a id='3'/>
+          </a>
+        </a>
+      </a>
+      XML
+      xmldoc = Document.new(doc)
+      result = XPath.match(xmldoc, "//a//a")
+      assert_equal(["1", "2", "3"], result.map { |e| e.attributes["id"] })
+    end
   end
 end


### PR DESCRIPTION
## Benchmark

```
$ benchmark-driver benchmark/xpath.yaml
                                                           before       after  before(YJIT)  after(YJIT) 
  REXML::XPath.match(REXML::Document.new(xml), 'a//a')     4.170k      4.300k        4.091k       4.087k i/s -     100.000 times in 0.023979s 0.023257s 0.024444s 0.024470s
REXML::XPath.match(REXML::Document.new(xml), '//a//a')    196.250      1.378k       293.984       1.701k i/s -     100.000 times in 0.509554s 0.072574s 0.340154s 0.058796s

Comparison:
               REXML::XPath.match(REXML::Document.new(xml), 'a//a')
                                                 after:      4299.8 i/s 
                                                before:      4170.3 i/s - 1.03x  slower
                                          before(YJIT):      4091.0 i/s - 1.05x  slower
                                           after(YJIT):      4086.6 i/s - 1.05x  slower

             REXML::XPath.match(REXML::Document.new(xml), '//a//a')
                                           after(YJIT):      1700.8 i/s 
                                                 after:      1377.9 i/s - 1.23x  slower
                                          before(YJIT):       294.0 i/s - 5.79x  slower
                                                before:       196.3 i/s - 8.67x  slower
```
- YJIT=ON : 0.99x - 5.79x faster
- YJIT=OFF : 1.03x - 7.01x faster