### PR TITLE
Optimize XPath step

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -338,15 +338,11 @@ module REXML
     end
 
     # Determines if a predicate expression is dependent on the position of nodes.
-    # nil if the predicate is position-independent,
-    # :simple if the predicate is a simple position query that can be optimized in axis scanning
-    # :complex if the predicate is a complex query that might be dependent on the position of nodes
-    def position_dependency(predicate_expr)
-      # [number], [position()=number], [position() < number], [position() > number]
-      return :simple if position_operation(predicate_expr)
-
-      # expressions that contain position-dependent functions
-      return :complex if calls_position_dependent_function?(predicate_expr)
+    # Returns false if the expression is guaranteed to be position-independent.
+    # Returns true if the expression might be position-dependent.
+    def position_dependent?(predicate_expr)
+      # expressions that contain position-dependent functions are position-dependent.
+      return true if calls_position_dependent_function?(predicate_expr)
 
       # Even if expression is followed by path steps, the analysis of
       # position dependency is the same as the expression itself.
@@ -354,32 +350,31 @@ module REXML
       when :union, :or, :and, :eq, :neq, :lt, :lteq, :gt, :gteq, :not
         # Expressions that don't evaluate to a number are position independent
         # if it doesn't contain position-dependent functions.
-        nil
+        false
       when :div, :mod, :mult, :plus, :minus, :neg
-        # expressions that return number. eg. `[position() = @attr + 1]`
-        :complex
+        # expressions that return number. eg. `[@attr + 1]`
+        true
       when :literal
-        # Integer literal is handled in `position_operation(predicate_expr)`.
-        # We treat this as complex(no-optimization) because this is not a normal case
-        # eg. `/foo["hi"]` `/bar[true]` `/baz[3.14]`
-        :complex
+        # Numeric literal is position dependent. String and boolean literal is useless
+        # and not worth optimizing
+        true
       when :variable
         # A variable could resolve to a number at runtime.
         # It's possible to optimize this by checking the actual value of the variable.
-        :complex
+        true
       when :function
         # functions that return number is position dependent. eg. `[position() = string-length(@attr)]`
-        %w[number ceiling round floor string-length sum count].include?(predicate_expr[1]) ? :complex : nil
+        %w[number ceiling round floor string-length sum count].include?(predicate_expr[1])
       when :group
-        position_dependency(predicate_expr[1])
+        position_dependent?(predicate_expr[1])
       when :descendant, :descendant_or_self, :ancestor, :ancestor_or_self,
            :following, :following_sibling, :preceding, :preceding_sibling,
            :document, :child, :self, :parent, :attribute, :namespace
         # paths are position independent. `foo[path[1]]` doesn't depend on the position of `foo`
-        nil
+        false
       else
-        # Every other unhandled expressions are treated as complex for safety
-        :complex
+        # Every other unhandled expressions are treated position dependent for safety
+        true
       end
     end
 
@@ -563,12 +558,12 @@ module REXML
     # If there are multiple position-based predicates or complex position-based predicates,
     # return [position_independent_predicates, nil, nil, complex_predicates]
     def split_positional_predicates(predicates)
-      pre_independent = predicates.take_while {|predicate| position_dependency(predicate).nil? }
+      pre_independent = predicates.take_while {|predicate| !position_dependent?(predicate) }
       predicates = predicates.drop(pre_independent.size)
       return [pre_independent, nil, [], nil] if predicates.empty?
 
       op = position_operation(predicates.first)
-      if op && predicates[1..-1].all? {|predicate| position_dependency(predicate).nil? }
+      if op && predicates[1..-1].all? {|predicate| !position_dependent?(predicate) }
         [pre_independent, op, predicates[1..-1], nil]
       else
         [pre_independent, nil, nil, predicates]

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -199,118 +199,48 @@ module REXML
           nodeset = [nodeset.first.root_node]
         when :self
           nodeset = step(path_stack) do
-            [nodeset]
+            [:iterate_nodesets, [nodeset]]
           end
         when :child
           nodeset = step(path_stack) do
-            child(nodeset)
+            [:iterate_nodesets, child(nodeset)]
           end
         when :literal
           trace(:literal, path_stack, nodeset) if @debug
           return path_stack.shift
         when :attribute
           nodeset = step(path_stack, any_type: :attribute) do
-            nodeset.map do |node|
+            nodesets = nodeset.map do |node|
               next unless node.node_type == :element
               attributes = node.attributes
               next if attributes.empty?
               attributes.each_attribute.to_a
             end.compact
+            [:iterate_nodesets, nodesets]
           end
         when :namespace
           warn 'Namespace axis is not supported in REXML::XPathParser', uplevel: 1
           # TODO: We need to create NamespaceNode class to support this feature
-          nodeset = step(path_stack) { [] }
+          nodeset = step(path_stack) { [:iterate_nodesets, []] }
         when :parent
           nodeset = step(path_stack) do
-            nodesets = []
+            parents = Set.new.compare_by_identity
             nodeset.each do |node|
               if node.node_type == :attribute
                 parent = node.element
               else
                 parent = node.parent
               end
-              nodesets << [parent] if parent
+              parents << parent if parent
             end
-            nodesets
+            [:iterate_nodesets, parents.map {|parent| [parent] }]
           end
-        when :ancestor
-          nodeset = step(path_stack, axis_order: :reverse) do
-            nodesets = []
-            # new_nodes = {}
-            nodeset.each do |node|
-              new_nodeset = []
-              while node.parent
-                node = node.parent
-                # next if new_nodes.key?(node)
-                new_nodeset << node
-                # new_nodes[node] = true
-              end
-              nodesets << new_nodeset unless new_nodeset.empty?
-            end
-            nodesets
-          end
-        when :ancestor_or_self
-          nodeset = step(path_stack, axis_order: :reverse) do
-            nodesets = []
-            # new_nodes = {}
-            nodeset.each do |node|
-              next unless node.node_type == :element
-              new_nodeset = [node]
-              # new_nodes[node] = true
-              while node.parent
-                node = node.parent
-                # next if new_nodes.key?(node)
-                new_nodeset << node
-                # new_nodes[node] = true
-              end
-              nodesets << new_nodeset unless new_nodeset.empty?
-            end
-            nodesets
-          end
-        when :descendant_or_self
+        when :ancestor, :ancestor_or_self,
+            :descendant, :descendant_or_self,
+            :preceding, :preceding_sibling,
+            :following, :following_sibling
           nodeset = step(path_stack) do
-            descendant(nodeset, true)
-          end
-        when :descendant
-          nodeset = step(path_stack) do
-            descendant(nodeset, false)
-          end
-        when :following_sibling
-          nodeset = step(path_stack) do
-            nodeset.map do |node|
-              next unless node.respond_to?(:parent)
-              next if node.parent.nil?
-              all_siblings = node.parent.children
-              current_index = all_siblings.index(node)
-              following_siblings = all_siblings[(current_index + 1)..-1]
-              next if following_siblings.empty?
-              following_siblings
-            end.compact
-          end
-        when :preceding_sibling
-          nodeset = step(path_stack, axis_order: :reverse) do
-            nodeset.map do |node|
-              next unless node.respond_to?(:parent)
-              next if node.parent.nil?
-              all_siblings = node.parent.children
-              current_index = all_siblings.index(node)
-              preceding_siblings = all_siblings[0, current_index].reverse
-              next if preceding_siblings.empty?
-              preceding_siblings
-            end.compact
-          end
-        when :preceding
-          nodeset = step(path_stack, axis_order: :reverse) do
-            nodeset.map do |node|
-              preceding(node)
-            end
-          end
-        when :following
-          nodeset = step(path_stack) do
-            nodeset.map do |node|
-              following(node)
-            end
+            [op, nodeset]
           end
         when :variable
           var_name = path_stack.shift
@@ -382,8 +312,7 @@ module REXML
             target_context[:position] = 1
           end
           args = arguments.dclone.collect do |arg|
-            result = expr(arg, nodeset, target_context)
-            result
+            expr(arg, nodeset, target_context)
           end
           @functions.context = target_context
           return @functions.send(func_name, *args)
@@ -394,7 +323,7 @@ module REXML
             # If result is a nodeset, apply following predicates
             path_stack.unshift(:node)
             nodeset = step(path_stack) do
-              [result]
+              [:iterate_nodesets, [result]]
             end
           else
             return result
@@ -408,120 +337,352 @@ module REXML
       leave(:expr, path_stack, nodeset) if @debug
     end
 
-    def step(path_stack, any_type: :element, axis_order: :forward)
-      nodesets = yield
-      begin
-        enter(:step, path_stack, nodesets) if @debug
-        nodesets = node_test(path_stack, nodesets, any_type: any_type)
-        while path_stack[0] == :predicate
-          path_stack.shift # :predicate
-          predicate_expression = path_stack.shift.dclone
-          nodesets = evaluate_predicate(predicate_expression, nodesets)
+    # Determines if a predicate expression is dependent on the position of nodes.
+    # nil if the predicate is position-independent,
+    # :simple if the predicate is a simple position query that can be optimized in axis scanning
+    # :complex if the predicate is a complex query that might be dependent on the position of nodes
+    def position_dependency(predicate_expr)
+      # [number], [position()=number], [position() < number], [position() > number]
+      return :simple if position_operation(predicate_expr)
+
+      # expressions that return number.
+      return :complex if %i[div mod mult plus minus neg].include?(predicate_expr[0])
+      return :complex if predicate_expr[0] == :function && %w[number ceiling round floor string-length sum count].include?(predicate_expr[1])
+      # Numeric literal including Integer and Float: [2] means [position() = 2]
+      return :complex if predicate_expr[0] == :literal && Numeric === predicate_expr[1]
+      # A variable could resolve to a number at runtime: [$n] means [position() = $n].
+      return :complex if predicate_expr[0] == :variable
+
+      # expressions that contain position-dependent functions
+      return :complex if calls_position_dependent_function?(predicate_expr)
+    end
+
+    # Recursively checks if the expression contains position-dependent functions such as position() or last()
+    def calls_position_dependent_function?(expr)
+      return false unless Array === expr
+      return true if expr[0] == :function && (expr[1] == 'position' || expr[1] == 'last')
+      expr.any? {|part| calls_position_dependent_function?(part) }
+    end
+
+    # Detects simple position-based predicates that can be optimized in axis scanning, such as [1], [position()=1], [position() < 2], [position() > 3]
+    # Returns operators and values such as [:==, 1], [:<, 2], [:>, 3]
+    # Returns nil if the predicate is not a simple position-based predicate
+    def position_operation(predicate_expr)
+      return [:==, predicate_expr[1]] if predicate_expr[0] == :literal && predicate_expr[1].is_a?(Integer)
+
+      op, left, right = predicate_expr
+      return unless op == :eq || op == :lt || op == :lteq || op == :gt || op == :gteq
+      return unless [left, right].include?([:function, 'position', []])
+
+      literal = [left, right].find {|part| part[0] == :literal && part[1].is_a?(Integer) }
+      return unless literal
+
+      value = literal[1]
+      case op
+      when :eq
+        [:==, value]
+      when :lt
+        literal == right ? [:<, value] : [:>, value]
+      when :lteq
+        literal == right ? [:<, value + 1] : [:>, value - 1]
+      when :gt
+        literal == right ? [:>, value]: [:<, value]
+      when :gteq
+        literal == right ? [:>, value - 1] : [:<, value + 1]
+      end
+    end
+
+    # Pseudo scanner for axis scanning step that nodesets are already collected
+    def iterate_nodesets(nodesets, tester, selector)
+      non_optimized_nodesets_select(nodesets, tester, selector)
+    end
+
+    # Scanner for ancestor-or-self axis
+    def ancestor_or_self(nodeset, tester, selector)
+      ancestor(nodeset, tester, selector, include_self: true)
+    end
+
+    # Scanner for preceding-sibling axis
+    def preceding_sibling(nodeset, tester, selector)
+      preceding_following_sibling(nodeset, tester, selector, reverse: true)
+    end
+
+    # Scanner for following-sibling axis
+    def following_sibling(nodeset, tester, selector)
+      preceding_following_sibling(nodeset, tester, selector, reverse: false)
+    end
+
+    def preceding_following_sibling(nodeset, tester, selector, reverse:)
+      nodeset = nodeset.select {|node| node.respond_to?(:parent) && node.parent }
+      case selector
+      when :uniq
+        nodeset.group_by(&:parent).flat_map do |parent, sibling_nodes|
+          sets = Set.new.compare_by_identity
+          sibling_nodes.each {|sibling| sets << sibling }
+          children = parent.children
+          children = children.reverse if reverse
+          children.drop_while {|child| !sets.include?(child) }.drop(1)
+        end.select(&tester)
+      when :nodesets
+        nodesets = nodeset.map do |node|
+          parent = node.parent
+          index = parent.children.index(node)
+          reverse ? parent.children[0...index].reverse : parent.children[index + 1..-1]
         end
-        if nodesets.size == 1
-          new_nodeset = axis_order == :forward ? nodesets.first : nodesets.first.reverse
-        else
-          nodes = Set.new.compare_by_identity
-          nodesets.each do |nodeset|
-            nodeset.each do |node|
-              nodes << node
+        non_optimized_nodesets_select(nodesets, tester, selector)
+      else
+        operator, value = selector
+        nodeset.group_by(&:parent).flat_map do |parent, sibling_nodes|
+          anchors = Set.new.compare_by_identity
+          sibling_nodes.each {|sibling| anchors << sibling }
+          children = parent.children
+          children = children.reverse if reverse
+          followings = children.drop_while {|child| !anchors.include?(child) }.drop(1)
+          anchor_indexes = Set[0]
+          last_anchor = 0
+          index = 0
+          matched = []
+          followings.each do |node|
+            if tester.call(node)
+              case operator
+              when :==
+                # anchor_indexes only contain values smaller or equal to `index`,
+                # so value <= 0 case doesn't accidentally match any node.
+                matched << node if anchor_indexes.include?(index - value + 1)
+              when :<
+                # Position from the last anchor will be the minimum possible position for the node
+                matched << node if index - last_anchor + 1 < value
+              when :>
+                # Position from the first anchor(==0) will be the maximum possible position for the node
+                matched << node if index + 1 > value
+              end
+              index += 1
+            end
+            if anchors.include?(node)
+              anchor_indexes << index
+              last_anchor = index
             end
           end
-          new_nodeset = sort(nodes.to_a)
+          matched
         end
-        new_nodeset
+      end
+    end
+
+    # Scanner for ancestor axis
+    def ancestor(nodeset, tester, selector, include_self: false)
+      nodeset = nodeset.select {|node| node.respond_to?(:parent) && node.parent }
+      case selector
+      when :uniq
+        ancestors = Set.new.compare_by_identity
+        nodeset.each do |node|
+          ancestors << node if include_self
+          parent = node.parent
+          while parent
+            break if ancestors.include?(parent)
+            ancestors << parent
+            parent = parent.parent
+          end
+        end
+        ancestors.select(&tester)
+      else
+        # Slow pass
+        nodesets = nodeset.map do |node|
+          ancestors = []
+          ancestors << node if include_self
+          parent = node.parent
+          while parent
+            ancestors << parent
+            parent = parent.parent
+          end
+          ancestors
+        end
+        non_optimized_nodesets_select(nodesets, tester, selector)
+      end
+    end
+
+    # Scanner fallback step for axis that is not optimized for position-based predicates.
+    def non_optimized_nodesets_select(nodesets, tester, selector)
+      nodesets = nodesets.map do |nodeset|
+        nodeset.select(&tester)
+      end.reject(&:empty?)
+      case selector
+      when :nodesets
+        nodesets
+      when :uniq
+        seen = Set.new.compare_by_identity
+        nodesets.flatten.each {|node| seen << node }
+        seen.to_a
+      else
+        operator, value = selector
+        nodes = nodesets.flatten
+        nodes =
+          case operator
+          when :==
+            nodesets.map {|nodeset| nodeset[value - 1] if value >= 1 }.compact
+          when :<
+            nodesets.map {|nodeset| nodeset[0...value - 1] if value >= 1 }.compact.flatten
+          when :>
+            nodesets.map {|nodeset| value < 0 ? nodeset : nodeset[value..-1] }.flatten
+          end
+        seen = Set.new.compare_by_identity
+        nodes.each {|node| seen << node }
+        seen.to_a
+      end
+    end
+
+    # Split predicates into several groups based on their dependency on the position of nodes
+    # If there are no position-based predicates,
+    # return [position_independent_predicates, nil, [], nil]
+    # If there are only one simple position-based predicate,
+    # return [position_independent_predicates, position_operator, post_position_independent_predicates, nil]
+    # If there are multiple position-based predicates or complex position-based predicates,
+    # return [position_independent_predicates, nil, nil, complex_predicates]
+    def split_positional_predicates(predicates)
+      pre_independent = predicates.take_while {|predicate| position_dependency(predicate).nil? }
+      predicates = predicates.drop(pre_independent.size)
+      return [pre_independent, nil, [], nil] if predicates.empty?
+
+      op = position_operation(predicates.first)
+      if op && predicates[1..-1].all? {|predicate| position_dependency(predicate).nil? }
+        [pre_independent, op, predicates[1..-1], nil]
+      else
+        [pre_independent, nil, nil, predicates]
+      end
+    end
+
+    # Performs an axis scanning step.
+    # The caller provides a scanner method and its argument, which determines the axis to scan and the nodes to scan from:
+    #   step(path_stack) { [scanner_method, scanner_argument] }
+    # Scanner method are called with `(scanner_argument, tester_block, selector)`
+    # selector is a flag for the scanner to determine how to return the scan result.
+    # It can be: `:uniq`, `:nodesets` or `[position_comparator, value]`.
+    # `:uniq` means the scanner should return unique nodes. Predicates are position-independent.
+    # `:nodesets` means the scanner should return nodesets. Predicates are complex position queries that can't be optimized in axis scanning.
+    # `[position_comparator, value]` means the scanner should return nodes matching the position comparator and value.
+    # Each scanner method can implement optimized scanning strategy for each selector.
+
+    def step(path_stack, any_type: :element)
+      scanner, scanner_argument = yield
+      begin
+        enter(:step, path_stack, scanner, scanner_argument) if @debug
+        tester = node_test(path_stack, any_type: any_type)
+        predicates = []
+        while path_stack.first == :predicate
+          path_stack.shift
+          predicates << path_stack.shift
+        end
+        pre_predicates, position_operator, post_predicates, complex_predicates = split_positional_predicates(predicates)
+
+        if pre_predicates.any?
+          original_tester = tester
+          tester = -> (node) do
+            original_tester.call(node) &&
+            pre_predicates.all? do |predicate_expr|
+              evaluate_predicate(predicate_expr.dclone, [[node]]).flatten.size == 1
+            end
+          end
+        end
+        if complex_predicates
+          nodesets = send(scanner, scanner_argument, tester, :nodesets)
+        elsif position_operator
+          nodeset = send(scanner, scanner_argument, tester, position_operator)
+          nodesets = [nodeset]
+        else
+          nodeset = send(scanner, scanner_argument, tester, :uniq)
+          nodesets = [nodeset]
+        end
+
+        (complex_predicates || post_predicates).each do |predicate_expr|
+          nodesets = evaluate_predicate(predicate_expr.dclone, nodesets)
+        end
+        nodes = Set.new.compare_by_identity
+        nodesets.each do |nodeset|
+          nodeset.each do |node|
+            nodes << node
+          end
+        end
+        new_nodeset = sort(nodes.to_a)
       ensure
         leave(:step, path_stack, new_nodeset) if @debug
       end
     end
 
-    def node_test(path_stack, nodesets, any_type: :element)
-      enter(:node_test, path_stack, nodesets) if @debug
+    def node_test(path_stack, any_type: :element)
+      enter(:node_test, path_stack) if @debug
       operator = path_stack.shift
       case operator
       when :qname
         prefix = path_stack.shift
         name = path_stack.shift
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            case node.node_type
-            when :element
-              if prefix.nil?
-                node.name == name
-              elsif prefix.empty?
-                if strict?
-                  node.name == name and node.namespace == ""
-                else
-                  node.name == name and node.namespace == get_namespace(node, prefix)
-                end
+        ->(node) do
+          case node.node_type
+          when :element
+            if prefix.nil?
+              node.name == name
+            elsif prefix.empty?
+              if strict?
+                node.name == name and node.namespace == ""
               else
                 node.name == name and node.namespace == get_namespace(node, prefix)
               end
-            when :attribute
-              if prefix.nil?
-                node.name == name
-              elsif prefix.empty?
-                node.name == name and node.namespace == ""
-              else
-                node.name == name and node.namespace == get_namespace(node.element, prefix)
-              end
             else
-              false
+              node.name == name and node.namespace == get_namespace(node, prefix)
             end
+          when :attribute
+            if prefix.nil?
+              node.name == name
+            elsif prefix.empty?
+              node.name == name and node.namespace == ""
+            else
+              node.name == name and node.namespace == get_namespace(node.element, prefix)
+            end
+          else
+            false
           end
         end
       when :namespace
         prefix = path_stack.shift
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            case node.node_type
-            when :element
-              namespaces = @namespaces || node.namespaces
-              node.namespace == namespaces[prefix]
-            when :attribute
-              namespaces = @namespaces || node.element.namespaces
-              node.namespace == namespaces[prefix]
-            else
-              false
-            end
+        ->(node) do
+          case node.node_type
+          when :element
+            namespaces = @namespaces || node.namespaces
+            node.namespace == namespaces[prefix]
+          when :attribute
+            namespaces = @namespaces || node.element.namespaces
+            node.namespace == namespaces[prefix]
+          else
+            false
           end
         end
       when :any
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            node.node_type == any_type
-          end
+        ->(node) do
+          node.node_type == any_type
         end
       when :comment
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            node.node_type == :comment
-          end
+        ->(node) do
+          node.node_type == :comment
         end
       when :text
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            node.node_type == :text
-          end
+        ->(node) do
+          node.node_type == :text
         end
       when :processing_instruction
         target = path_stack.shift
-        new_nodesets = nodesets.collect do |nodeset|
-          nodeset.select do |node|
-            (node.node_type == :processing_instruction) and
-              (target.empty? or (node.target == target))
-          end
+        ->(node) do
+          (node.node_type == :processing_instruction) and
+            (target.empty? or (node.target == target))
         end
       when :node
-        new_nodesets = nodesets
+        ->(_node) do
+          true
+        end
       else
         message = "[BUG] Unexpected node test: " +
           "<#{operator.inspect}>: <#{path_stack.inspect}>"
         raise message
       end
-      new_nodesets
     ensure
-      leave(:node_test, path_stack, new_nodesets) if @debug
+      leave(:node_test, path_stack) if @debug
     end
 
     def evaluate_predicate(expression, nodesets)
@@ -581,6 +742,8 @@ module REXML
     # I wouldn't have to do this.  Maybe add a document IDX for each node?
     # Problems with mutable documents.  Or, rewrite everything.
     def sort(array_of_nodes)
+      return array_of_nodes if array_of_nodes.size <= 1
+
       new_arry = []
       array_of_nodes.each { |node|
         node_idx = []
@@ -599,15 +762,43 @@ module REXML
       end
     end
 
-    def descendant(nodeset, include_self)
-      nodesets = []
-      nodeset.each do |node|
-        new_nodeset = []
-        new_nodes = {}
-        descendant_recursive(node, new_nodeset, new_nodes, include_self)
-        nodesets << new_nodeset unless new_nodeset.empty?
+    # Scanner for descendant-or-self axis
+    def descendant_or_self(nodeset, tester, selector)
+      descendant(nodeset, tester, selector, include_self: true)
+    end
+
+    # Scanner for descendant axis
+    def descendant(nodeset, tester, selector, include_self: false)
+      nodeset = nodeset.select {|node| node.respond_to?(:children) }
+      case selector
+      when :uniq
+        seen = Set.new.compare_by_identity
+        recursive = ->(node) do
+          node_type = node.node_type
+          return if seen.include?(node)
+          seen << node if node_type != :xmldecl
+          return unless node_type == :element || node_type == :document
+          node.children.each do |child|
+            recursive.call(child)
+          end
+        end
+        nodeset.each do |node|
+          if include_self
+            recursive.call(node)
+          else
+            node.children.each(&recursive)
+          end
+        end
+        seen.select(&tester)
+      else
+        nodesets = nodeset.map do |node|
+          new_nodeset = []
+          new_nodes = {}
+          descendant_recursive(node, new_nodeset, new_nodes, include_self)
+          new_nodeset
+        end
+        non_optimized_nodesets_select(nodesets, tester, selector)
       end
-      nodesets
     end
 
     def descendant_recursive(node, new_nodeset, new_nodes, include_self)
@@ -625,11 +816,17 @@ module REXML
       end
     end
 
+    # Scanner for preceding axis
+    def preceding(nodeset, tester, selector)
+      nodesets = nodeset.select {|node| node.respond_to?(:parent) }.map {|node| preceding_nodes(node) }
+      non_optimized_nodesets_select(nodesets, tester, selector)
+    end
+
     # Builds a nodeset of all of the preceding nodes of the supplied node,
     # in reverse document order
     # preceding:: includes every element in the document that precedes this node,
     # except for ancestors
-    def preceding(node)
+    def preceding_nodes(node)
       ancestors = []
       parent = node.parent
       while parent
@@ -665,7 +862,15 @@ module REXML
       psn
     end
 
-    def following(node)
+    # Scanner for following axis
+    def following(nodeset, tester, selector)
+      nodesets = nodeset.select {|node| node.respond_to?(:parent) }.map do |node|
+        following_nodes(node)
+      end
+      non_optimized_nodesets_select(nodesets, tester, selector)
+    end
+
+    def following_nodes(node)
       followings = []
       following_node = next_sibling_node(node)
       while following_node

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -345,16 +345,42 @@ module REXML
       # [number], [position()=number], [position() < number], [position() > number]
       return :simple if position_operation(predicate_expr)
 
-      # expressions that return number.
-      return :complex if %i[div mod mult plus minus neg].include?(predicate_expr[0])
-      return :complex if predicate_expr[0] == :function && %w[number ceiling round floor string-length sum count].include?(predicate_expr[1])
-      # Numeric literal including Integer and Float: [2] means [position() = 2]
-      return :complex if predicate_expr[0] == :literal && Numeric === predicate_expr[1]
-      # A variable could resolve to a number at runtime: [$n] means [position() = $n].
-      return :complex if predicate_expr[0] == :variable
-
       # expressions that contain position-dependent functions
       return :complex if calls_position_dependent_function?(predicate_expr)
+
+      # Even if expression is followed by path steps, the analysis of
+      # position dependency is the same as the expression itself.
+      case predicate_expr[0]
+      when :union, :or, :and, :eq, :neq, :lt, :lteq, :gt, :gteq, :not
+        # Expressions that don't evaluate to a number are position independent
+        # if it doesn't contain position-dependent functions.
+        nil
+      when :div, :mod, :mult, :plus, :minus, :neg
+        # expressions that return number. eg. `[position() = @attr + 1]`
+        :complex
+      when :literal
+        # Integer literal is handled in `position_operation(predicate_expr)`.
+        # We treat this as complex(no-optimization) because this is not a normal case
+        # eg. `/foo["hi"]` `/bar[true]` `/baz[3.14]`
+        :complex
+      when :variable
+        # A variable could resolve to a number at runtime.
+        # It's possible to optimize this by checking the actual value of the variable.
+        :complex
+      when :function
+        # functions that return number is position dependent. eg. `[position() = string-length(@attr)]`
+        %w[number ceiling round floor string-length sum count].include?(predicate_expr[1]) ? :complex : nil
+      when :group
+        position_dependency(predicate_expr[1])
+      when :descendant, :descendant_or_self, :ancestor, :ancestor_or_self,
+           :following, :following_sibling, :preceding, :preceding_sibling,
+           :document, :child, :self, :parent, :attribute, :namespace
+        # paths are position independent. `foo[path[1]]` doesn't depend on the position of `foo`
+        nil
+      else
+        # Every other unhandled expressions are treated as complex for safety
+        :complex
+      end
     end
 
     # Recursively checks if the expression contains position-dependent functions such as position() or last()
@@ -514,15 +540,14 @@ module REXML
         seen.to_a
       else
         operator, value = selector
-        nodes = nodesets.flatten
         nodes =
           case operator
           when :==
             nodesets.map {|nodeset| nodeset[value - 1] if value >= 1 }.compact
           when :<
-            nodesets.map {|nodeset| nodeset[0...value - 1] if value >= 1 }.compact.flatten
+            nodesets.flat_map {|nodeset| nodeset[0...value - 1] if value >= 1 }.compact
           when :>
-            nodesets.map {|nodeset| value < 0 ? nodeset : nodeset[value..-1] }.flatten
+            nodesets.flat_map {|nodeset| value <= 0 ? nodeset : nodeset.drop(value) }
           end
         seen = Set.new.compare_by_identity
         nodes.each {|node| seen << node }
@@ -553,7 +578,7 @@ module REXML
     # Performs an axis scanning step.
     # The caller provides a scanner method and its argument, which determines the axis to scan and the nodes to scan from:
     #   step(path_stack) { [scanner_method, scanner_argument] }
-    # Scanner method are called with `(scanner_argument, tester_block, selector)`
+    # Scanner methods are called with `(scanner_argument, tester_block, selector)`
     # selector is a flag for the scanner to determine how to return the scan result.
     # It can be: `:uniq`, `:nodesets` or `[position_comparator, value]`.
     # `:uniq` means the scanner should return unique nodes. Predicates are position-independent.

--- a/test/xpath/test_attribute.rb
+++ b/test/xpath/test_attribute.rb
@@ -32,5 +32,20 @@ module REXMLTests
                                     "nothing" => "")
       assert_equal(["child2"], children.collect(&:text))
     end
+
+    def test_attribute_axis_with_other_axes_does_not_raise
+      # Some of those are not yet supported in REXML, but at least it shouldn't raise an error
+      assert_nothing_raised do
+        REXML::XPath.match(@document, '//attribute::*/parent::*')
+        REXML::XPath.match(@document, '//attribute::*/preceding::*')
+        REXML::XPath.match(@document, '//attribute::*/following::*')
+        REXML::XPath.match(@document, '//attribute::*/preceding-sibling::*')
+        REXML::XPath.match(@document, '//attribute::*/following-sibling::*')
+        REXML::XPath.match(@document, '//attribute::*/ancestor::*')
+        REXML::XPath.match(@document, '//attribute::*/descendant::*')
+        REXML::XPath.match(@document, '//attribute::*/ancestor-or-self::*')
+        REXML::XPath.match(@document, '//attribute::*/descendant-or-self::*')
+      end
+    end
   end
 end

--- a/test/xpath/test_axis_preceding_sibling.rb
+++ b/test/xpath/test_axis_preceding_sibling.rb
@@ -34,5 +34,83 @@ module REXMLTests
       prev = XPath.first(context, "preceding-sibling::f[3]")
       assert_equal "3", prev.attributes["id"]
     end
+
+    def test_preceding_sibling_position_less_than
+      context = XPath.first(@@doc, "/a/e/f[last()]")
+      assert_equal([], XPath.match(context, "preceding-sibling::f[position() < 1]"))
+      assert_equal(["5"],
+                   XPath.match(context, "preceding-sibling::f[position() < 2]").map {|n| n.attributes["id"] })
+      assert_equal(["4", "5"],
+                   XPath.match(context, "preceding-sibling::f[position() < 3]").map {|n| n.attributes["id"] })
+    end
+
+    def test_preceding_sibling_position_less_than_or_equal
+      context = XPath.first(@@doc, "/a/e/f[last()]")
+      assert_equal([], XPath.match(context, "preceding-sibling::f[position() <= 0]"))
+      assert_equal(["4", "5"],
+                   XPath.match(context, "preceding-sibling::f[position() <= 2]").map {|n| n.attributes["id"] })
+    end
+
+    def test_preceding_sibling_position_greater_than
+      context = XPath.first(@@doc, "/a/e/f[last()]")
+      assert_equal(["3", "4", "5"],
+                   XPath.match(context, "preceding-sibling::f[position() > 0]").map {|n| n.attributes["id"] })
+      assert_equal(["3", "4"],
+                   XPath.match(context, "preceding-sibling::f[position() > 1]").map {|n| n.attributes["id"] })
+      assert_equal(["3"],
+                   XPath.match(context, "preceding-sibling::f[position() > 2]").map {|n| n.attributes["id"] })
+    end
+
+    def test_preceding_sibling_position_greater_than_or_equal
+      context = XPath.first(@@doc, "/a/e/f[last()]")
+      assert_equal(["3", "4", "5"],
+                   XPath.match(context, "preceding-sibling::f[position() >= 0]").map {|n| n.attributes["id"] })
+      assert_equal(["3", "4", "5"],
+                   XPath.match(context, "preceding-sibling::f[position() >= 1]").map {|n| n.attributes["id"] })
+      assert_equal(["3", "4"],
+                   XPath.match(context, "preceding-sibling::f[position() >= 2]").map {|n| n.attributes["id"] })
+    end
+
+    def test_preceding_following_sibling_multiple_anchors
+      doc = Document.new(<<~XML)
+        <a>
+          <garbage/>
+          <b id='1'/>
+          <b id='2'/>
+          <b id='3'/>
+          <garbage/>
+          <b id='4'/>
+          <anchor id='a1'/>
+          <b id='5'/>
+          <b id='6'/>
+          <garbage/>
+          <garbage/>
+          <b id='7'/>
+          <b id='8'/>
+          <garbage/>
+          <b id='9'/>
+          <anchor id='a2'/>
+          <garbage/>
+          <b id='10'/>
+          <b id='11'/>
+          <anchor id='a3'/>
+          <b id='12'/>
+        </a>
+      XML
+
+      assert_equal(%w[2 7 9], XPath.match(doc, "/a/anchor/preceding-sibling::b[position() = 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[2 3 4 7 8 9 10 11], XPath.match(doc, "/a/anchor/preceding-sibling::b[position() <= 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[1 2 3 4 5 6 7 8], XPath.match(doc, "/a/anchor/preceding-sibling::b[position() >= 4]").map {|n| n.attributes["id"] })
+      assert_equal(%w[2 7 a2], XPath.match(doc, "/a/anchor/preceding-sibling::*[@id][position() = 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[2 3 4 7 8 9 a2 10 11], XPath.match(doc, "/a/anchor/preceding-sibling::*[@id][position() <= 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[1 2 3 4 a1 5 6 7 8 9], XPath.match(doc, "/a/anchor/preceding-sibling::*[@id][position() >= 4]").map {|n| n.attributes["id"] })
+
+      assert_equal(%w[7 12], XPath.match(doc, "/a/anchor/following-sibling::b[position() = 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[5 6 7 10 11 12], XPath.match(doc, "/a/anchor/following-sibling::b[position() <= 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[8 9 10 11 12], XPath.match(doc, "/a/anchor/following-sibling::b[position() >= 4]").map {|n| n.attributes["id"] })
+      assert_equal(%w[7 a3], XPath.match(doc, "/a/anchor/following-sibling::*[@id][position() = 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[5 6 7 10 11 a3 12], XPath.match(doc, "/a/anchor/following-sibling::*[@id][position() <= 3]").map {|n| n.attributes["id"] })
+      assert_equal(%w[8 9 a2 10 11 a3 12], XPath.match(doc, "/a/anchor/following-sibling::*[@id][position() >= 4]").map {|n| n.attributes["id"] })
+    end
   end
 end

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -500,6 +500,14 @@ module REXMLTests
       assert_equal(["w", "x", "y", "z"], matches.map(&:name))
     end
 
+    def test_following_sibling_position_less_than
+      source = "<r><a/><b/><c/><d/></r>"
+      doc = REXML::Document.new(source)
+      assert_equal([], REXML::XPath.match(doc, "/r/a/following-sibling::*[position() < 1]"))
+      assert_equal(["b"], REXML::XPath.match(doc, "/r/a/following-sibling::*[position() < 2]").map(&:name))
+      assert_equal(["b", "c"], REXML::XPath.match(doc, "/r/a/following-sibling::*[position() < 3]").map(&:name))
+    end
+
     def test_preceding_sibling_across_multiple_nodes
       source = <<-XML
 <a>

--- a/test/xpath/test_predicate.rb
+++ b/test/xpath/test_predicate.rb
@@ -59,10 +59,48 @@ module REXMLTests
       assert_equal( "1", m[0].attributes["id"] )
     end
 
+    def test_predicate_multi_position
+      xml = <<~XML
+        <a>
+          <b><c id="1"/><c id="2"/><c id="3"/><c id="4"/><c id="5"/></b>
+          <b><c id="6"/><c id="7"/><c id="8"/><c id="9"/><c id="10"/></b>
+        </a>
+      XML
+      doc = REXML::Document.new(xml)
+
+      result = REXML::XPath.match(doc, "/a/b/c[position()>1]")
+      assert_equal(%w[2 3 4 5 7 8 9 10], result.map { |node| node.attributes["id"] })
+
+      result = REXML::XPath.match(doc, "/a/b/c[position()>1][position()>1]")
+      assert_equal(%w[3 4 5 8 9 10], result.map { |node| node.attributes["id"] })
+
+      result = REXML::XPath.match(doc, "/a/b/c[position()>1][position()>1][@id!='3']")
+      assert_equal(%w[4 5 8 9 10], result.map { |node| node.attributes["id"] })
+
+      result = REXML::XPath.match(doc, "/a/b/c[position()>1][position()>1][@id!='3'][position()!=2]")
+      assert_equal(%w[4 8 10], result.map { |node| node.attributes["id"] })
+    end
+
     def do_path( path )
       m = REXML::XPath.match( @doc, path )
       #puts path, @parser.parse( path ).inspect
       return m
+    end
+
+    def test_predicate_float_literal
+      doc = REXML::Document.new("<r><a/><b/><c/><d/></r>")
+      # [N.0] is equivalent to [position() = N.0] = [position() = N]
+      assert_equal(["a"], REXML::XPath.match(doc, "/r/*[1.0]").map(&:name))
+      assert_equal(["b"], REXML::XPath.match(doc, "/r/*[2.0]").map(&:name))
+      # Non-integer numeric literals match no node.
+      assert_equal([], REXML::XPath.match(doc, "/r/*[1.5]"))
+    end
+
+    def test_predicate_variable_as_position
+      doc = REXML::Document.new("<r><a/><b/><c/><d/></r>")
+      parser = REXML::XPathParser.new
+      parser["x"] = 2
+      assert_equal(["b"], parser.parse("/r/*[$x]", doc).map(&:name))
     end
 
     def test_get_no_siblings_terminal_nodes

--- a/test/xpath/test_predicate.rb
+++ b/test/xpath/test_predicate.rb
@@ -103,6 +103,46 @@ module REXMLTests
       assert_equal(["b"], parser.parse("/r/*[$x]", doc).map(&:name))
     end
 
+    def test_predicate_out_of_range_position
+      doc = REXML::Document.new("<r><a/><b/><c/><d/></r>")
+      parser = REXML::XPathParser.new
+      base = '/r/*'
+      assert_equal([], parser.parse("#{base}[-1]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base}[0]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base}[5]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base}[position()>5]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base}[position()<0]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base}[position()<-1]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base}[position()>0]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base}[position()>-1]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base}[position()<10]", doc).map(&:name))
+
+      # non-optimizable case
+      base_no_opt = '/r/*[position()!=name()]'
+      assert_equal([], parser.parse("#{base_no_opt}[-1]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base_no_opt}[0]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base_no_opt}[5]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base_no_opt}[position()>5]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base_no_opt}[position()<0]", doc).map(&:name))
+      assert_equal([], parser.parse("#{base_no_opt}[position()<-1]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base_no_opt}[position()>0]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base_no_opt}[position()>-1]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("#{base_no_opt}[position()<10]", doc).map(&:name))
+    end
+
+    def test_predicate_parenthesized_position
+      doc = REXML::Document.new("<r><a/><b/><c/><d/></r>")
+      parser = REXML::XPathParser.new
+      assert_equal(["b"], parser.parse("/r/*[(2)]", doc).map(&:name))
+    end
+
+    def test_position_dependent_function_predicates
+      doc = REXML::Document.new("<r><a/><b/><c/><d/></r>")
+      parser = REXML::XPathParser.new
+      assert_equal(["b"], parser.parse("/r/*['2'=string(-(0 - position())*1)]", doc).map(&:name))
+      assert_equal(%w[a b c d], parser.parse("/r/*['4'=string(-(0 - last())*1)]", doc).map(&:name))
+    end
+
     def test_get_no_siblings_terminal_nodes
       source = <<-XML
 <a>


### PR DESCRIPTION
Refactor `step` so that nodeset materialization is deferred. Instead of building the full nodeset up front and filtering through predicates,
each axis returns a *scan descriptor* (`[generator_name, generator_argument]`), and `step` picks a scan strategy based on the predicates' shape.

Predicates are classified into three groups:

| kind | examples | strategy passed to the generator |
|---|---|---|
| position-independent | `[@a="1"]`, `[name()="foo"]`, `[@a=@b]` | `:uniq` — emit deduplicated matching nodes |
| simple positional | `[N]`, `[position()=N]`, `[position()>N]`, `[position()<N]` | `[op, value]` — positional scan with one comparison |
| complex / position-dependent | `[position()*@a]`, `[last()-1]`, ... | `:nodesets` — fall back to per-anchor nodesets + the previous `evaluate_predicate` pipeline |

Mixed predicate lists are split: position-independent predicates *before* the first positional predicate are folded into the node test;
predicates *after* it are applied per-node on the result.

Each axis can implement zero, one, or all of the three strategies. If a strategy is not implemented, the generator falls back to producing
`:nodesets` and the common slow path (`non_optimized_nodesets_select`) handles dedup / positional filtering on flattened nodesets — i.e. the
same behavior as before this PR.

This pull request adds fast paths for:

- `descendant` / `descendant-or-self`: `:uniq` (single DFS with a seen-set; this is what speeds up `//a//a//a//a`)
- `ancestor` / `ancestor-or-self`: `:uniq` (parent-chain walk with a seen-set)
- `preceding-sibling` / `following-sibling`: `:uniq` and `[op, value]` (sibling scan with anchor-index tracking)

Other axes (`child`, `parent`, `self`, `attribute`, `preceding`, `following`, etc) keeps the previous behavior via the fallback path; they can be optimized in follow-ups without changing call sites.

## Detail

For `//a//a//a` style queries, the previous code built nodesets keyed by each anchor, including the same descendant once per anchor. The new
`:uniq` path scans every node at most once per step.

For `[position() > N]` style predicates on wide trees (e.g. `//a/preceding-sibling::*[position()>2]`), we previously built the full
preceding-sibling nodeset for each anchor and then ran `evaluate_predicate`. The new `[op, value]` path scans children once per parent and uses
anchor-index bookkeeping to recover per-anchor positions.

Note: general XPath cannot be linear — e.g. `*[position() * number(@a) % number(@b) = 1]` is genuinely O(n²) — so the goal is only to add a fast-path for specific case: position-independent predicates and simple-positional predicates.

## Benchmark of best case

```ruby
DEPTH = 500
xml   = '<a>' * DEPTH + '</a>' * DEPTH
doc   = REXML::Document.new(xml)
WIDTH = 1000
xml_wide = '<root>' + '<child/>' * WIDTH + '</root>'
doc_wide = REXML::Document.new(xml_wide)

REXML::XPath.match(doc, "//a//a");
# processing time: 30.756939s → 0.126807s

REXML::XPath.match(doc_wide, "//*/preceding-sibling::*[position()=10]");
# processing time: 2.446333s → 0.083954s
```

## Benchmark of various case

### Scenario
```yaml
prelude: |
  require "rexml"
  xml_wide = "<root>" + (1..1000).map { |i| "<item id='#{i}'/>" }.join + "</root>"
  wide = REXML::Document.new(xml_wide)
  xml_deep = "<root>" + (1..1000).map { |i| "<item id='#{i}'>" }.join + '</item>'*1000 + "</root>"
  deep = REXML::Document.new(xml_deep)

benchmark:
  child: REXML::XPath.match(wide, "root/item")
  descendant: REXML::XPath.match(deep, "//item")
  descendant-descendant: REXML::XPath.match(deep, "//item//item")
  descendant-descendant-wildcard: REXML::XPath.match(deep, "//*//*")
  ancestor-descendant: REXML::XPath.match(deep, "descendant::*/ancestor::*/descendant::*")
  preceding-following-sibling: REXML::XPath.match(wide, "//*/preceding-sibling::*/following-sibling::*")
  preceding-following-sibling-positional: REXML::XPath.match(wide, "//*/preceding-sibling::*[10]/following-sibling::*[10]")
```

### Compares
master, xpath_step_optimize (this pull), sort_on_demand(#330), sort_improve(Emulate ideal sort computation time), and its combinations.

There's no implementation of `sort_improve` yet, so I used the code below to emulate the computational cost of ideal sort.
```ruby
def sort(array_of_nodes)
  # Just spend time to emulate the ideal computational cost of sorting nodes
  parents = Set.new.compare_by_identity
  array_of_nodes.each { parents << it.parent if it.parent }
  4.times do
    # find the common ancestor
    nodes = array_of_nodes
    seen = Set.new.compare_by_identity
    while nodes.size >= 2
      new_nodes = Set.new.compare_by_identity
      nodes.map(&:parent).each do |parent|
        if parent && !seen.include?(parent)
          seen << parent
          new_nodes << parent
        end
      end
      nodes = new_nodes
    end
    # iterate each node's siblings
    parents.each{it.children.each{}}
  end
  array_of_nodes # not sorted
end
```

### Result
```
Comparison:
                                              child
                                master:      1288.1 i/s 
                   master_sort_improve:      1190.4 i/s - 1.08x  slower
xpath_step_optimize_sort_on_demand_sort_improve:       875.3 i/s - 1.47x  slower
      xpath_step_optimize_sort_improve:       861.3 i/s - 1.50x  slower
    xpath_step_optimize_sort_on_demand:        92.3 i/s - 13.96x  slower
                   xpath_step_optimize:        91.7 i/s - 14.05x  slower
                        sort_on_demand:        90.6 i/s - 14.21x  slower

                                         descendant
                   master_sort_improve:        75.5 i/s 
xpath_step_optimize_sort_on_demand_sort_improve:        75.1 i/s - 1.01x  slower
      xpath_step_optimize_sort_improve:        68.8 i/s - 1.10x  slower
                        sort_on_demand:        21.4 i/s - 3.52x  slower
    xpath_step_optimize_sort_on_demand:        21.4 i/s - 3.52x  slower
                                master:        20.9 i/s - 3.61x  slower
                   xpath_step_optimize:        11.7 i/s - 6.45x  slower

                              descendant-descendant
xpath_step_optimize_sort_on_demand_sort_improve:        47.5 i/s 
      xpath_step_optimize_sort_improve:        41.9 i/s - 1.13x  slower
    xpath_step_optimize_sort_on_demand:        17.9 i/s - 2.65x  slower
                   master_sort_improve:         8.6 i/s - 5.54x  slower
                        sort_on_demand:         6.7 i/s - 7.07x  slower
                   xpath_step_optimize:         6.1 i/s - 7.84x  slower
                                master:         4.6 i/s - 10.24x  slower

                     descendant-descendant-wildcard
xpath_step_optimize_sort_on_demand_sort_improve:       339.5 i/s 
      xpath_step_optimize_sort_improve:       155.9 i/s - 2.18x  slower
    xpath_step_optimize_sort_on_demand:        26.4 i/s - 12.86x  slower
                   master_sort_improve:        10.0 i/s - 33.96x  slower
                        sort_on_demand:         7.7 i/s - 44.30x  slower
                   xpath_step_optimize:         6.8 i/s - 50.06x  slower
                                master:         4.9 i/s - 68.58x  slower

                                ancestor-descendant
xpath_step_optimize_sort_on_demand_sort_improve:       377.9 i/s 
      xpath_step_optimize_sort_improve:       203.7 i/s - 1.85x  slower
    xpath_step_optimize_sort_on_demand:        26.3 i/s - 14.39x  slower
                   xpath_step_optimize:         8.7 i/s - 43.24x  slower
                   master_sort_improve:         7.8 i/s - 48.55x  slower
                        sort_on_demand:         6.3 i/s - 59.93x  slower
                                master:         5.0 i/s - 75.46x  slower

                        preceding-following-sibling
xpath_step_optimize_sort_on_demand_sort_improve:       684.1 i/s 
      xpath_step_optimize_sort_improve:       424.5 i/s - 1.61x  slower
    xpath_step_optimize_sort_on_demand:        85.8 i/s - 7.98x  slower
                   xpath_step_optimize:        23.7 i/s - 28.91x  slower
                   master_sort_improve:        20.9 i/s - 32.72x  slower
                        sort_on_demand:        19.3 i/s - 35.39x  slower
                                master:        13.9 i/s - 49.11x  slower

             preceding-following-sibling-positional
xpath_step_optimize_sort_on_demand_sort_improve:       425.4 i/s 
      xpath_step_optimize_sort_improve:       315.0 i/s - 1.35x  slower
    xpath_step_optimize_sort_on_demand:        84.3 i/s - 5.05x  slower
                   xpath_step_optimize:        23.3 i/s - 18.22x  slower
                   master_sort_improve:         2.1 i/s - 201.38x  slower
                        sort_on_demand:         2.1 i/s - 204.75x  slower
                                master:         1.9 i/s - 222.08x  slower
```

In scenario "child" and "descendant", this PR is slower than master because it adds one additional `sort` call. The difference will be small when `sort` is improved.
In most case, this PR itself does not unleash its full potential because sort is the next bottleneck. Combining with `sort` improvement is important.
The difference of "descendant-descendant" and "descendant-descendant-wildcard" shows that after optimizing sort, the bottleneck will be namespace lookup in qname check for deeply nested xml.
