### PR TITLE
Fix parsing xpath that has mult without surrounding spaces

### DIFF
--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -591,14 +591,15 @@ module REXML
         path = path.lstrip
         n = []
         rest = FilterExpr( path, n )
-        if rest != path
+        if rest == path
+          rest = LocationPath(rest, n)
+        else
           if rest and rest[0] == ?/
             rest = RelativeLocationPath(rest, n)
             parsed.concat(n)
             return rest
           end
         end
-        rest = LocationPath(rest, n) if rest =~ /\A[\/\.\@\[\w*]/
         parsed.concat(n)
         rest
       end

--- a/test/parser/test_xpath.rb
+++ b/test/parser/test_xpath.rb
@@ -111,5 +111,18 @@ module REXMLTests
                      abbreviate("a/b[attribute::name='double \" quote']/c"))
       end
     end
+
+    def test_mult_and_spaces
+      parser = REXML::Parsers::XPathParser.new
+      assert_equal(parser.parse("1 * 2 * 3"), parser.parse("1*2*3"))
+      assert_equal(parser.parse("a[( ( 1 + 2 ) * 3 + 4 * ( 5 + 6 ) ) * 7 < 8]"), parser.parse("a[((1+2)*3+4*(5+6))*7<8]"))
+      # number(a/b) * 2
+      assert_equal(parser.parse("(a/b) * 2"), parser.parse("(a/b)*2"))
+      assert_equal(parser.parse("a/b * 2"), parser.parse("a/b*2"))
+      # number(a/b/*) * 2
+      assert_equal(parser.parse("a/b/* * 2"), parser.parse("a/b/**2"))
+      # number(*) * number(*/*) * number(*)
+      assert_equal(parser.parse("* * */* * *"), parser.parse("***/***"))
+    end
   end
 end


### PR DESCRIPTION
Fix PathExpr's implementation to match its source code comments. Fixes parsing xpath such as `/a[(1+2)*3]`.


```ruby
REXML::Parsers::XPathParser.new.parse("(1+2) * 3")
#=> [:mult, [:plus, [:literal, 1], [:literal, 2]], [:literal, 3]]
REXML::Parsers::XPathParser.new.parse("(1+2)*3")
#=> REXML::ParseException (before)
#=> [:mult, [:plus, [:literal, 1], [:literal, 2]], [:literal, 3]] (after)

REXML::Parsers::XPathParser.new.parse("a[(1+2)*3]")
#=> [:child, :qname, "", "a", :predicate, [:plus, [:literal, 1], [:literal, 2], :child, :any]] (before)
#=> [:child, :qname, "", "a", :predicate, [:mult, [:plus, [:literal, 1], [:literal, 2]], [:literal, 3]]] (after)
```


Source code comment:
```
#| LocationPath
#| FilterExpr ('/' | '//') RelativeLocationPath 
```
Actual implementation was:
```
#| LocationPath
#| FilterExpr ('/' | '//') RelativeLocationPath
#| FilterExpr ('/' | '//') RelativeLocationPath LocationPath
```
LocationPath was eating the mult operator `*` as `child` axis.