### PR TITLE
Fix parsing parenthesized xpath

### DIFF
--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -587,7 +587,9 @@ module REXML
         path = path.lstrip
         n = []
         rest = FilterExpr( path, n )
-        if rest != path
+        if rest == path
+          rest = LocationPath(rest, n)
+        else
           if /\A\s*\//.match?(rest)
             rest = rest.lstrip
             if rest.start_with?('//')
@@ -598,11 +600,8 @@ module REXML
               rest = rest[1..-1]
             end
             rest = RelativeLocationPath(rest, n)
-            parsed.concat(n)
-            return rest
           end
         end
-        rest = LocationPath(rest, n) if rest =~ /\A[\/\.\@\[\w*]/
         parsed.concat(n)
         rest
       end

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -588,7 +588,15 @@ module REXML
         n = []
         rest = FilterExpr( path, n )
         if rest != path
-          if rest and rest[0] == ?/
+          if /\A\s*\//.match?(rest)
+            rest = rest.lstrip
+            if rest.start_with?('//')
+              n << :descendant_or_self
+              n << :node
+              rest = rest[2..-1]
+            else # starts with '/'
+              rest = rest[1..-1]
+            end
             rest = RelativeLocationPath(rest, n)
             parsed.concat(n)
             return rest

--- a/test/parser/test_xpath.rb
+++ b/test/parser/test_xpath.rb
@@ -129,5 +129,18 @@ module REXMLTests
         parser.parse('//processing-instruction( "a" )'),
       )
     end
+
+    def test_mult_asterisk_without_surrounding_spaces
+      parser = REXML::Parsers::XPathParser.new
+      assert_equal(parser.parse("1 * 2 * 3"), parser.parse("1*2*3"))
+      assert_equal(parser.parse("a[( ( 1 + 2 ) * 3 + 4 * ( 5 + 6 ) ) * 7 < 8]"), parser.parse("a[((1+2)*3+4*(5+6))*7<8]"))
+      # number(a/b) * 2
+      assert_equal(parser.parse("(a/b) * 2"), parser.parse("(a/b)*2"))
+      assert_equal(parser.parse("a/b * 2"), parser.parse("a/b*2"))
+      # number(a/b/*) * 2
+      assert_equal(parser.parse("a/b/* * 2"), parser.parse("a/b/**2"))
+      # number(*) * number(*/*) * number(*)
+      assert_equal(parser.parse("* * */* * *"), parser.parse("***/***"))
+    end
   end
 end

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -616,6 +616,33 @@ module REXMLTests
       assert_equal without_parentheses, with_parentheses
     end
 
+    def test_parenthesized_xpath
+      doc = Document.new <<-EOF
+        <div>
+          <div id='1'>
+            <test>ab</test>
+            <div><test>cd</test></div>
+          </div>
+          <div id='2'>
+            <test>ef</test>
+            <div><test>gh</test></div>
+          </div>
+          <div>
+            <test>hi</test>
+          </div>
+        </div>
+      EOF
+      parenthesized_xpath = '(//div[@id="1"] | //div[@id="2"])'
+      assert_equal(%w[ab ef], XPath.match(doc, "#{parenthesized_xpath}/test").map(&:text))
+      assert_equal(%w[ab ef], XPath.match(doc, "#{parenthesized_xpath} / test").map(&:text))
+      assert_equal(%w[ab cd ef gh], XPath.match(doc, "#{parenthesized_xpath}//test").map(&:text))
+      assert_equal(%w[ab cd ef gh], XPath.match(doc, "#{parenthesized_xpath} // test").map(&:text))
+      assert_equal(%w[ab], XPath.match(doc, "#{parenthesized_xpath}[@id='1']/test").map(&:text))
+      assert_equal(%w[ef gh], XPath.match(doc, "#{parenthesized_xpath}[@id='2']//test").map(&:text))
+      assert_equal(%w[ef], XPath.match(doc, "#{parenthesized_xpath}[2] / test").map(&:text))
+      assert_equal(%w[ab cd], XPath.match(doc, "#{parenthesized_xpath}[1] // test").map(&:text))
+    end
+
     # Contributed by Mike Stok
     def test_starts_with
       source = <<-EOF


### PR DESCRIPTION
Fixes #316

Also fixes bug parsing `(1+2)*3`

```ruby
REXML::Parsers::XPathParser.new.parse("(a|b)/c")
#=> REXML::ParseException (before)
#=> [:group, [:union, [:child, :qname, "", "a"], [:child, :qname, "", "b"]], :child, :qname, "", "c"] (after)

REXML::Parsers::XPathParser.new.parse("(1+2) * 3")
#=> [:mult, [:plus, [:literal, 1], [:literal, 2]], [:literal, 3]]
REXML::Parsers::XPathParser.new.parse("(1+2)*3")
#=> REXML::ParseException (before)
#=> [:mult, [:plus, [:literal, 1], [:literal, 2]], [:literal, 3]] (after)
```


Source code comment:
```ruby
#| LocationPath
#| FilterExpr ('/' | '//') RelativeLocationPath 
```
Actual implementation was:

```ruby
#| LocationPath
#| FilterExpr (RelativeLocationPath if this_part.start_with?('/'))
#| FilterExpr (RelativeLocationPath if this_part.start_with?('/')) LocationPath
#| FilterExpr LocationPath
# Note that RelativeLocationPath never accepts string starting with `/`
```
With this pull request, the implementation will match to its source code comment.