### PR TITLE
Remove XPath namespace axis handling part which is not working at all

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -223,30 +223,9 @@ module REXML
             nodesets
           end
         when :namespace
-          pre_defined_namespaces = {
-            "xml" => "http://www.w3.org/XML/1998/namespace",
-          }
-          nodeset = step(path_stack, any_type: :namespace) do
-            nodesets = []
-            nodeset.each do |node|
-              raw_node = node.raw_node
-              case raw_node.node_type
-              when :element
-                if @namespaces
-                  nodesets << pre_defined_namespaces.merge(@namespaces)
-                else
-                  nodesets << pre_defined_namespaces.merge(raw_node.namespaces)
-                end
-              when :attribute
-                if @namespaces
-                  nodesets << pre_defined_namespaces.merge(@namespaces)
-                else
-                  nodesets << pre_defined_namespaces.merge(raw_node.element.namespaces)
-                end
-              end
-            end
-            nodesets
-          end
+          warn 'Namespace axis is not supported in REXML::XPathParser', uplevel: 1
+          # TODO: We need to create NamespaceNode class to support this feature
+          nodeset = step(path_stack) { [] }
         when :parent
           nodeset = step(path_stack) do
             nodesets = []

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -248,6 +248,14 @@ module REXMLTests
       assert_equal 19, q.attributes["id"].to_i
     end
 
+    def test_axe_namespace_no_error
+      $VERBOSE, verbose = nil, $VERBOSE
+      # Although namespace axis is not implemented yet, it should not raise NoMethodError
+      XPath.match(@@doc, "a/d/c/namespace::*")
+    ensure
+      $VERBOSE = verbose
+    end
+
     def test_abbreviated_attribute
       assert_equal 'a', XPath::first( @@doc, "a[@id='1']" ).name
       c = XPath::first( @@doc, "a/b/c[@id='4']" )


### PR DESCRIPTION
Namespace axis should return a nodeset of Namespace Node, but Namespace Node class has not even been defined yet.
So namespace axis is completely unimplemented.
Right now, this incomplete code is just getting in the way of refactoring.

```ruby
REXML::XPath.match(REXML::Document.new('<root/>'), '//*/namespace::*')
# before:
# => in REXML::XPathParser#node_test': undefined method 'raw_node' for an instance of Array (NoMethodError)

# after:
# warning: Namespace axis is not supported in REXML::XPathParser
# => []
```

Other options:
- Silently return empty nodeset
- Always raise error with a message
