### PR TITLE
Fix XPath normalize-space function

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -262,13 +262,8 @@ module REXML
       string(string).length
     end
 
-    def Functions::normalize_space( string=nil )
-      string = string(@@context[:node]) if string.nil?
-      if string.kind_of? Array
-        string.collect{|x| x.to_s.strip.gsub(/\s+/um, ' ') if x}
-      else
-        string.to_s.strip.gsub(/\s+/um, ' ')
-      end
+    def Functions::normalize_space( object=@@context[:node] )
+      string(object).strip.gsub(/\s+/um, ' ')
     end
 
     # This is entirely Mike Stok's beast

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -242,13 +242,18 @@ Coffee beans
 </c><d>        Dessert
  \t\t    after    dinner</d></a>
       XML
-      normalized_texts = REXML::XPath.each(REXML::Document.new(source), "normalize-space(//text())").to_a
-      assert_equal([
-                     "breakfast boosts concentration",
-                     "Coffee beans aroma",
-                     "Dessert after dinner",
-                   ],
-                   normalized_texts)
+      doc = REXML::Document.new(source)
+      # First node should be used for normalize-space, and the rest should be ignored.
+      assert_equal(["breakfast boosts concentration"], REXML::XPath.match(doc, "normalize-space(//text())"))
+      assert_equal(["Coffee beans aroma"], REXML::XPath.match(doc, "normalize-space(//c/text())"))
+      assert_equal(["Dessert after dinner"], REXML::XPath.match(doc, "normalize-space(//d/text())"))
+    end
+
+    def test_normalize_space_without_argument
+      source = "<root><item> foo </item><item> bar </item><item> baz </item></root>"
+      doc = REXML::Document.new(source)
+      match = REXML::XPath.match(doc, "//item[normalize-space()='bar']")
+      assert_equal([" bar "], match.map(&:text))
     end
 
     def test_string_nil_without_context


### PR DESCRIPTION
It should return normalized string of the first node, just like other functions such as `string()` and `number()`

```ruby
doc = Nokogiri::XML.parse(<<~XML)
  <a><b>breakfast     boosts\t\t
  
  concentration   </b><c>
  Coffee beans
  aroma
  </c><d>        Dessert
  \t\t    after    dinner</d></a>
XML
doc.xpath("normalize-space(//text())")
#=> "breakfast boosts concentration"
```

This bug is a blocker of implementing delayed nodeset ordering.
```ruby
def match(path_stack, node)
  nodeset = [XPathNode.new(node, position: 1)]
  result = expr(path_stack, nodeset)
  case result
  when Array # nodeset ← HERE, normalize-space function returned array of string
    unnode(result).uniq # Changing to sort(result) failed
  else
    [result]
  end
end
```