### PR TITLE
Primitive value should't be wrapped in an array

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -74,13 +74,17 @@ module REXML
     end
 
     def Functions::namespace_uri( node_set=nil )
-      get_namespace( node_set ) {|node| node.namespace}
+      get_namespace( node_set ) do |node|
+        return node.namespace
+      end
+      ""
     end
 
     def Functions::name( node_set=nil )
       get_namespace( node_set ) do |node|
-        node.expanded_name
+        return node.expanded_name
       end
+      ""
     end
 
     # Helper method.

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -313,7 +313,7 @@ module REXML
           end
         when :variable
           var_name = path_stack.shift
-          return [@variables[var_name]]
+          return @variables[var_name]
 
         when :eq, :neq, :lt, :lteq, :gt, :gteq
           left = expr( path_stack.shift, nodeset.dup, context )

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -533,16 +533,13 @@ module REXML
           subcontext[:position] = position
           result = expr(expression.dclone, [node], subcontext)
           trace(:predicate_evaluate, expression, node, subcontext, result) if @debug
-          result = result[0] if result.kind_of? Array and result.length == 1
           if result.kind_of? Numeric
             if result == position
               new_nodeset << node
             end
           elsif result.instance_of? Array
-            if result.size > 0 and result.inject(false) {|k,s| s or k}
-              if result.size > 0
-                new_nodeset << node
-              end
+            if result.size > 0
+              new_nodeset << node
             end
           else
             if result


### PR DESCRIPTION
Similar to #324
Values should be nodeset(Array) or primitive, not `[primitive]`

Also removes these workarounds related to primitive wrapped in array
```ruby
# Workaround to handle single primitive value wrapped in an array
result = result[0] if result.kind_of? Array and result.length == 1

# Workaround to handle multiple primitive values wrapped in an array
# Arrays are always nodeset, so `if result.size > 0` is enough
if result.size > 0 and result.inject(false) {|k,s| s or k}
```

It works even wrapping with an array, but leaving it will be a blocker of implementing delayed nodeset ordering.
