### PR TITLE
Remove unused xpath function text() and processing-instruction()

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -419,10 +419,6 @@ module REXML
       end
     end
 
-    def Functions::processing_instruction( node )
-      node.node_type == :processing_instruction
-    end
-
     def Functions::send(name, *args)
       if @@available_functions[name.to_sym]
         super

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -37,16 +37,6 @@ module REXML
 
     def Functions::context=(value); @@context = value; end
 
-    def Functions::text( )
-      if @@context[:node].node_type == :element
-        @@context[:node].find_all{|n| n.node_type == :text}.collect{|n| n.value}
-      elsif @@context[:node].node_type == :text
-        @@context[:node].value
-      else
-        false
-      end
-    end
-
     # Returns the last node of the given list of nodes.
     def Functions::last( )
       @@context[:size]


### PR DESCRIPTION
Related to #326
Functions must return nodeset or a primitive value. Functions::text() returning an array of string is a bug to be fixed. Although, `text()` in xpath is resolved as `[:child, :text]`, it's not a function, so Functions::text is unused.

Also removes `Functions::processing_instruction`. These are node-test, not functions.