### PR TITLE
Simplify element.attributes structure

### DIFF
--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -180,7 +180,7 @@ module REXML
     #
     # This method is usually not called directly.
     def remove
-      @element.attributes.delete self.name unless @element.nil?
+      @element.attributes.delete self unless @element.nil?
     end
 
     # Writes this attribute (EG, puts 'key="value"' to the output)
@@ -204,6 +204,15 @@ module REXML
 
     def document
       @element&.document
+    end
+
+    # Returns true if this attribute is a namespace declaration, false otherwise.
+    #   "foo" => false
+    #   "xmlns" => true
+    #   "xmlns:foo" => true
+    #   "foo:xmlns" => false
+    def namespace_declaration?
+      prefix == 'xmlns' || (prefix.empty? && name == 'xmlns')
     end
   end
 end

--- a/lib/rexml/attribute.rb
+++ b/lib/rexml/attribute.rb
@@ -176,7 +176,7 @@ module REXML
       self
     end
 
-    # Removes this Attribute from the tree, and returns true if successful
+    # Removes this Attribute from the tree
     #
     # This method is usually not called directly.
     def remove

--- a/lib/rexml/doctype.rb
+++ b/lib/rexml/doctype.rb
@@ -113,23 +113,27 @@ module REXML
     end
 
     def attributes_of element
-      rv = []
-      each do |child|
-        child.each do |key,val|
-          rv << Attribute.new(key,val)
-        end if child.kind_of? AttlistDecl and child.element_name == element
+      attribute_declarations_of(element).map do |key, value|
+        Attribute.new(key, value)
       end
-      rv
     end
 
     def attribute_of element, attribute
-      att_decl = find do |child|
-        child.kind_of? AttlistDecl and
-        child.element_name == element and
-        child.include? attribute
+      attribute_declarations_of(element)[attribute]
+    end
+
+    def attribute_declarations_of(name)
+      raw_attributes = {}
+      decls = select do |child|
+        child.kind_of?(AttlistDecl) && child.element_name == name
       end
-      return nil unless att_decl
-      att_decl[attribute]
+      decls.each do |child|
+        child.each do |key, val|
+          # First declaration wins
+          raw_attributes[key] = val unless raw_attributes.key? key
+        end
+      end
+      raw_attributes
     end
 
     def clone

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -2430,7 +2430,7 @@ module REXML
     #   d = REXML::Document.new(xml_string)
     #   ele = d.root.elements['//ele'] # => <a foo:att='1' bar:att='2' att='&lt;'/>
     #   attrs = ele.attributes
-    #   attrs # => {"att"=>{"foo"=>foo:att='1', "bar"=>bar:att='2', ""=>att='&lt;'}}
+    #   attrs # => {"foo:att" => foo:att='1', "bar:att" => bar:att='2', "att" => att='&lt;'}
     #   attrs.add(REXML::Attribute.new('foo:att', '2')) # => foo:att='2'
     #   attrs.add(REXML::Attribute.new('baz', '3')) # => baz='3'
     #   attrs.include?('baz') # => true

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -2240,15 +2240,10 @@ module REXML
     #   [REXML::Attribute, bar:att='2']
     #   [REXML::Attribute, att='&lt;']
     #
-    def each_attribute # :yields: attribute
-      return to_enum(__method__) unless block_given?
-      each_value do |val|
-        if val.kind_of? Attribute
-          yield val
-        else
-          val.each_value { |atr| yield atr }
-        end
-      end
+    # This method doesn't iterate attributes in the DTD. This may be a bug.
+    #
+    def each_attribute(&block) # :yields: attribute
+      each_own_attribute(&block)
     end
 
     # :call-seq:
@@ -2272,6 +2267,8 @@ module REXML
     #   ["foo:att", "1"]
     #   ["bar:att", "2"]
     #   ["att", "<"]
+    #
+    # This method doesn't iterate attributes in the DTD. This may be a bug.
     #
     def each
       return to_enum(__method__) unless block_given?
@@ -2300,36 +2297,7 @@ module REXML
     #   attrs.get_attribute('nosuch')        # => nil
     #
     def get_attribute( name )
-      attr = fetch( name, nil )
-      if attr.nil?
-        return nil if name.nil?
-        # Look for prefix
-        name =~ Namespace::NAMESPLIT
-        prefix, n = $1, $2
-        if prefix
-          attr = fetch( n, nil )
-          # check prefix
-          if attr == nil
-          elsif attr.kind_of? Attribute
-            return attr if prefix == attr.prefix
-          else
-            attr = attr[ prefix ]
-            return attr
-          end
-        end
-        doctype = @element.document&.doctype
-        if doctype
-          expn = @element.expanded_name
-          expn = doctype.name if expn.size == 0
-          attr_val = doctype.attribute_of(expn, name)
-          return Attribute.new( name, attr_val ) if attr_val
-        end
-        return nil
-      end
-      if attr.kind_of? Hash
-        attr = attr[ @element.prefix ]
-      end
-      attr
+      fetch(name, nil) || attlist_attributes&.[](name)
     end
 
     # :call-seq:
@@ -2357,12 +2325,15 @@ module REXML
     #
     def []=( name, value )
       if value.nil?             # Delete the named attribute
-        attr = get_attribute(name)
-        delete attr
+        delete name
         return
       end
 
-      unless value.kind_of? Attribute
+      if value.kind_of? Attribute
+        # Use attribute's expanded name to avoid inconsistency.
+        # TODO: Explicitly document that inconsistent names are allowed, or raise/warn about inconsistency.
+        name = value.expanded_name
+      else
         doctype = @element.document&.doctype
         if doctype
           value = Text::normalize( value, doctype )
@@ -2372,17 +2343,7 @@ module REXML
         value = Attribute.new(name, value)
       end
       value.element = @element
-      old_attr = fetch(value.name, nil)
-      if old_attr.nil?
-        store(value.name, value)
-      elsif old_attr.kind_of? Hash
-        old_attr[value.prefix] = value
-      elsif old_attr.prefix != value.prefix
-        store value.name, {old_attr.prefix => old_attr,
-                           value.prefix    => value}
-      else
-        store value.name, value
-      end
+      store name, value
       @element
     end
 
@@ -2398,20 +2359,7 @@ module REXML
     #   d.root.attributes.prefixes # => ["x", "y"]
     #
     def prefixes
-      ns = []
-      each_attribute do |attribute|
-        ns << attribute.name if attribute.prefix == 'xmlns'
-      end
-      doctype = @element.document&.doctype
-      if doctype
-        expn = @element.expanded_name
-        expn = doctype.name if expn.size == 0
-        doctype.attributes_of(expn).each {
-          |attribute|
-          ns << attribute.name if attribute.prefix == 'xmlns'
-        }
-      end
-      ns
+      namespaces.keys - ['xmlns']
     end
 
     # :call-seq:
@@ -2425,17 +2373,8 @@ module REXML
     #
     def namespaces
       namespaces = {}
-      each_attribute do |attribute|
-        namespaces[attribute.name] = attribute.value if attribute.prefix == 'xmlns' or attribute.name == 'xmlns'
-      end
-      doctype = @element.document&.doctype
-      if doctype
-        expn = @element.expanded_name
-        expn = doctype.name if expn.size == 0
-        doctype.attributes_of(expn).each {
-          |attribute|
-          namespaces[attribute.name] = attribute.value if attribute.prefix == 'xmlns' or attribute.name == 'xmlns'
-        }
+      each_effective_attribute do |attribute|
+        namespaces[attribute.name] = attribute.value if attribute.namespace_declaration?
       end
       namespaces
     end
@@ -2468,28 +2407,11 @@ module REXML
     #   attrs.delete(attr) # => <ele att='&lt;'/> # => <ele att='&lt;'/>
     #   attrs.delete(attr) # => <ele att='&lt;'/> # => <ele/>
     #
-    def delete( attribute )
-      name = nil
-      prefix = nil
-      if attribute.kind_of? Attribute
-        name = attribute.name
-        prefix = attribute.prefix
-      else
-        attribute =~ Namespace::NAMESPLIT
-        prefix, name = $1, $2
-        prefix = '' unless prefix
-      end
-      old = fetch(name, nil)
-      if old.kind_of? Hash # the supplied attribute is one of many
-        old.delete(prefix)
-        if old.size == 1
-          repl = nil
-          old.each_value{|v| repl = v}
-          store name, repl
-        end
-      elsif old # the supplied attribute is a top-level one
-        super(name)
-      end
+    def delete(attribute_or_name)
+      key = attribute_or_name
+      key = attribute_or_name.expanded_name if attribute_or_name.kind_of? Attribute
+      super(key)
+
       @element
     end
 
@@ -2514,7 +2436,7 @@ module REXML
     #   attrs.include?('baz') # => true
     #
     def add( attribute )
-      self[attribute.name] = attribute
+      self[attribute.expanded_name] = attribute
     end
 
     alias :<< :add
@@ -2527,21 +2449,26 @@ module REXML
     #
     #   xml_string = <<-EOT
     #     <root xmlns:foo="http://foo" xmlns:bar="http://bar">
-    #        <ele foo:att='1' bar:att='2' att='&lt;'/>
+    #        <ele foo:att='1' att='&lt;' foo:other='2' other='3'/>
     #     </root>
     #   EOT
     #   d = REXML::Document.new(xml_string)
-    #   ele = d.root.elements['//ele'] # => <a foo:att='1' bar:att='2' att='&lt;'/>
+    #   ele = d.root.elements['//ele'] # => <a foo:att='1' att='&lt;' foo:other='2' other='3'/>
     #   attrs = ele.attributes
-    #   attrs.delete_all('att') # => [att='&lt;']
+    #   attrs.delete_all('att') # => [foo:att='1', att='&lt;']
+    #   attrs.each_attribute.map(&:expanded_name) #=> ['foo:other', 'other']
     #
     def delete_all( name )
-      rv = []
-      each_attribute { |attribute|
-        rv << attribute if attribute.expanded_name == name
-      }
-      rv.each{ |attr| attr.remove }
-      rv
+      attributes = each_attribute.select do |attribute|
+        # For <element xmlns:foo="url" ns:foo="value"/>
+        # delete_all('foo') should not delete xmlns:foo="url"
+        # because it is a namespace declaration, not a normal attribute.
+        (!attribute.namespace_declaration? && attribute.name == name) || attribute.expanded_name == name
+      end
+      attributes.each do |attribute|
+        delete attribute.expanded_name
+      end
+      attributes
     end
 
     # :call-seq:
@@ -2562,17 +2489,51 @@ module REXML
     #   attrs.get_attribute_ns('http://foo', 'nosuch') # => nil
     #
     def get_attribute_ns(namespace, name)
-      result = nil
-      each_attribute() { |attribute|
-        if name == attribute.name &&
-          namespace == attribute.namespace() &&
-          ( !namespace.empty? || !attribute.fully_expanded_name.index(':') )
-          # foo will match xmlns:foo, but only if foo isn't also an attribute
-          result = attribute if !result or !namespace.empty? or
-                                !attribute.fully_expanded_name.index(':')
+      each_effective_attribute.find do |attribute|
+        if attribute.namespace_declaration?
+          # namespace declarations are not considered as attributes in this method.
+          # For example: <elem1 xmlns="" xmlns:foo="url" /><elem2 xmlns="bar" xmlns:foo="url" />
+          # Both elem1.get_attribute_ns('', 'foo') and elem2.get_attribute_ns('bar', 'foo')
+          # should not match.
+          false
+        elsif namespace.empty? && !attribute.prefix.empty?
+          # If prefix is present, namespace url shouldn't be empty, so it never matches.
+          # For example, <elem foo:att="value" />, even if attribute.namespace returns '',
+          # it just means that namespace lookup failed, it shouldn't match.
+          false
+        else
+          name == attribute.name && namespace == attribute.namespace()
         end
-      }
-      result
+      end
+    end
+
+    private
+
+    # Iterates over the attributes of the element and those in the DTD.
+    # If the element has an attribute with the same name as one in the DTD,
+    # the element's attribute takes precedence.
+    def each_effective_attribute
+      return to_enum(__method__) unless block_given?
+      attr = attlist_attributes
+      attr = attr ? attr.merge(self) : self
+      attr.each_value do |attribute|
+        yield attribute
+      end
+    end
+
+    alias each_own_attribute each_value
+    private :each_own_attribute
+
+    def attlist_attributes
+      doctype = @element.document&.doctype
+      if doctype
+        expn = @element.is_a?(Document) ? doctype.name : @element.expanded_name
+        doctype.attribute_declarations_of(expn).map do |key, value|
+          attr = Attribute.new(key, value)
+          attr.element = @element
+          [key, attr]
+        end.to_h
+      end
     end
   end
 end

--- a/test/test_attribute.rb
+++ b/test/test_attribute.rb
@@ -8,5 +8,14 @@ module REXMLTests
                    "\#{PREFIX}:\#{LOCAL_NAME} or \#{LOCAL_NAME}: <\":x\">",
                    error.message)
     end
+
+    def test_namespace_declaration
+      assert_equal(false, REXML::Attribute.new("name").namespace_declaration?)
+      assert_equal(false, REXML::Attribute.new("prefix:name").namespace_declaration?)
+      assert_equal(false, REXML::Attribute.new("prefix:xmlns").namespace_declaration?)
+      assert_equal(true, REXML::Attribute.new("xmlns").namespace_declaration?)
+      assert_equal(true, REXML::Attribute.new("xmlns:name").namespace_declaration?)
+      # REXML::Attribute.new("xmlns:xmlns") is not tested because it's invalid
+    end
   end
 end

--- a/test/test_attributes.rb
+++ b/test/test_attributes.rb
@@ -74,6 +74,16 @@ module REXMLTests
       assert_equal '4', doc.root.attributes['z:foo']
     end
 
+    def test_delete_all
+      doc = Document.new("<a xmlns:x='x' xmlns:y='y' x:x='0' y:x='1' x='2' y='3' x:y='4' x:z='5' y:y='6'/>")
+      doc.root.attributes.delete_all 'x'
+      assert_equal ['xmlns:x', 'xmlns:y', 'y', 'x:y', 'x:z', 'y:y'], doc.root.attributes.each_attribute.map(&:expanded_name)
+      doc.root.attributes.delete_all 'x:y'
+      assert_equal ['xmlns:x', 'xmlns:y', 'y', 'x:z', 'y:y'], doc.root.attributes.each_attribute.map(&:expanded_name)
+      doc.root.attributes.delete_all 'xmlns:y'
+      assert_equal ['xmlns:x', 'y', 'x:z', 'y:y'], doc.root.attributes.each_attribute.map(&:expanded_name)
+    end
+
     def test_prefixes
       doc = Document.new("<a xmlns='foo' xmlns:x='bar' xmlns:y='twee' z='glorp' x:k='gru'/>")
       prefixes = doc.root.attributes.prefixes

--- a/test/test_attributes_mixin.rb
+++ b/test/test_attributes_mixin.rb
@@ -5,8 +5,10 @@ module REXMLTests
     def setup
       @ns_a = "urn:x-test:a"
       @ns_b = "urn:x-test:b"
+      @ns_default = "urn:x-test:default"
       element_string = <<-"XMLEND"
-      <test xmlns:a="#{@ns_a}"
+      <test xmlns="#{@ns_default}"
+            xmlns:a="#{@ns_a}"
             xmlns:b="#{@ns_b}"
             a = "1"
             b = '2'
@@ -25,6 +27,8 @@ module REXMLTests
       assert_equal("4", @attributes.get_attribute_ns(@ns_a, "d").value)
       assert_equal("5", @attributes.get_attribute_ns(@ns_a, "e").value)
       assert_equal("6", @attributes.get_attribute_ns(@ns_b, "f").value)
+      assert_nil(@attributes.get_attribute_ns(@ns_default, "a"))
+      assert_nil(@attributes.get_attribute_ns("", "xmlns"))
     end
   end
 end

--- a/test/test_contrib.rb
+++ b/test/test_contrib.rb
@@ -286,10 +286,10 @@ EOF
       aDoc = REXML::Document.new '<h1 tpl:content="title" xmlns:tpl="1">Dummy title</h1>'
 
       anElement = anElement = aDoc.elements[1]
-      elementAttrPrefix = anElement.attributes.get_attribute('content').prefix
+      elementAttrPrefix = anElement.attributes.get_attribute('tpl:content').prefix
 
       aClone = anElement.clone
-      cloneAttrPrefix = aClone.attributes.get_attribute('content').prefix
+      cloneAttrPrefix = aClone.attributes.get_attribute('tpl:content').prefix
 
       assert_equal( elementAttrPrefix , cloneAttrPrefix )
     end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -889,15 +889,24 @@ EOL
       <!ATTLIST a
         bar          CDATA "gobble"
         xmlns:one    CDATA  "two"
+        one:baz      CDATA "three"
       >
       ]>
       <a xmlns:three='xxx' three='yyy'><one:b/><three:c/></a>
       EOL
       assert_equal '<!ATTLIST blah xmlns CDATA "foo">', doc.doctype.children[0].to_s.gsub(/\s+/, " ")
       assert_equal 'gobble', doc.root.attributes['bar']
+      assert_equal 'gobble', doc.root.attributes.get_attribute('bar').value
+      assert_equal 'three', doc.root.attributes.get_attribute('one:baz').value
+      assert_equal 'three', doc.root.attributes.get_attribute_ns('two', 'baz').value
       assert_equal 'xxx', doc.root.elements[2].namespace
       assert_equal 'two', doc.root.elements[1].namespace
       assert_equal 'foo', doc.root.namespace
+
+      # Not used in REXML internal any more, keep for backward compatibility
+      assert_equal 'gobble', doc.doctype.attribute_of('a', 'bar')
+      expected_attributes = [Attribute.new('bar', 'gobble'), Attribute.new('xmlns:one', 'two'), Attribute.new('one:baz', 'three')]
+      assert_equal expected_attributes, doc.doctype.attributes_of('a')
 
       doc = Document.new <<~EOL
       <?xml version="1.0"?>
@@ -1537,12 +1546,10 @@ ENDXML
            'inkscape:version="0.44" version="1.0"/>'
       )
       expected = {
-        "inkscape" => attribute("xmlns:inkscape",
+        "xmlns:inkscape" => attribute("xmlns:inkscape",
                                 "http://www.inkscape.org/namespaces/inkscape"),
-        "version" => {
-          "inkscape" => attribute("inkscape:version", "0.44"),
-          "" => attribute("version", "1.0"),
-        },
+        "inkscape:version" => attribute("inkscape:version", "0.44"),
+        "version" => attribute("version", "1.0"),
       }
       assert_equal(expected,
                    doc.root.attributes.to_h)


### PR DESCRIPTION
Basically refactor Attributes, and fixes some bugs found while doing it.

## Structure of Attributes, a subclass of Hash
For XML: `<element name1="1" ns1:name2="2" ns2:name2="3" ns1:name3="4"/>`, the structure was:
```ruby
{
  name1 => attr1
  name2 => { ns1 => attr2, ns2 => attr3 }
  name3 => att4
}
```
This structure is useful for fuzzy name search, and fuzzy name deletion, but we don't need this complicated structure because fuzzy search should be removed, and fuzzy deletion is not used from REXML (and it wasn't working at all)

I think the mental model of namespaced attribute in Document Object Model is something like this.
```ruby
{ default: { name1: attr1 }, ns1: { name2: attr1, name3: attr4}, ns2: { name2: attr2 } }
# or simply
{ "name1": attr1, "ns1:name2": attr2, "ns2: name2": attr3, "ns1:name3": attr4 }
```
This PR changes it to the latter, simple one.

## Stop fuzzy get_attribute/get_attribute_ns search

`Attributes#get_attribute` does fuzzy search only on its own attribute, not on attributes defined in ATTLIST. `Attributes#get_attribute_ns` tries fuzzy search but fails because of a bug.
In Document Object Model, get_attribute and get_attribute_ns should perform strictly no-prefix attribute if prefix/namespace is not given.

## ATTLIST lookup
There's many redundant duplicated code for ATTLIST lookup.
`Attributes#get_attribute_ns` forgot to check ATTLIST (bug).
Introduce `each_effective_attribute` that iterates attributes defined in ATTLIST and element's own attributes

## Fixed bugs
- get_attribute: Fuzzy search shouldn't be performed
- get_attribute_ns: forgot to lookup ATTLIST
- delete_all: Unlike the name that indicates fuzzy deletion, it deletes only one attribute, and returns wrong attrribute which is a different one than actually deleted when prefix is given.
- namespace declaration check: `foo:xmnls` was wrongly considered namespace declaration
- And perhaps more which I haven't found yet