### PR TITLE
Fix XPath self axis nodeset position

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -199,7 +199,7 @@ module REXML
           nodeset = [nodeset.first.root_node]
         when :self
           nodeset = step(path_stack) do
-            [:iterate_nodesets, [nodeset]]
+            [:iterate_nodesets, nodeset.map {|node| [node] }]
           end
         when :child
           nodeset = step(path_stack) do

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -276,6 +276,12 @@ module REXMLTests
       assert_equal "c", XPath::first( c, "self::node()" ).name
     end
 
+    def test_axe_self_order
+      doc = REXML::Document.new "<a><b/><c/><d/></a>"
+      assert_equal(["b", "c", "d"], XPath.match(doc, "a/*/self::*[1]").map(&:name))
+      assert_equal([], XPath.match(doc, "a/*/self::*[2]").map(&:name))
+    end
+
     def test_axe_ancestor
       doc = REXML::Document.new "
       <a>


### PR DESCRIPTION
Self axis should create nodesets that each node have position=1

```ruby
Nokogiri::XML('<a><b/><c/><d/></a>').xpath('a/*/self::*[1]').map(&:name)
# => ["b", "c", "d"]

REXML::XPath.match(REXML::Document.new('<a><b/><c/><d/></a>'),'a/*/self::*[1]')
#=> [<b/>] (master, rexml-3.4.4)
#=> [<b/>, <c/>, <d/>] (this PR)
```
