### PR TITLE
Optimize preceding-sibling, following-sibling, following, and descendant axes with an unified single mechanism

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -467,57 +467,18 @@ module REXML
 
     def preceding_following_sibling(nodeset, tester, selector, reverse:)
       nodeset = nodeset.select {|node| node.respond_to?(:parent) && node.parent }
-      operator, value = selector
-      case operator
-      when :uniq
-        nodeset.group_by(&:parent).flat_map do |parent, sibling_nodes|
-          sets = Set.new.compare_by_identity
-          sibling_nodes.each {|sibling| sets << sibling }
-          children = parent.children
-          children = children.reverse if reverse
-          children.drop_while {|child| !sets.include?(child) }.drop(1)
-        end.select(&tester)
-      when :index_eq, :index_lt, :index_gt
-        nodeset.group_by(&:parent).flat_map do |parent, sibling_nodes|
-          anchors = Set.new.compare_by_identity
-          sibling_nodes.each {|sibling| anchors << sibling }
-          children = parent.children
-          children = children.reverse if reverse
-          followings = children.drop_while {|child| !anchors.include?(child) }.drop(1)
-          anchor_indexes = Set[0]
-          last_anchor = 0
-          index = 0
-          matched = []
-          followings.each do |node|
-            if tester.call(node)
-              case operator
-              when :index_eq
-                # anchor_indexes only contain values smaller or equal to `index`,
-                # so value < 0 case doesn't accidentally match any node.
-                matched << node if anchor_indexes.include?(index - value)
-              when :index_lt
-                # Position from the last anchor will be the minimum possible position for the node
-                matched << node if index - last_anchor < value
-              when :index_gt
-                # Position from the first anchor(==0) will be the maximum possible position for the node
-                matched << node if index > value
-              end
-              index += 1
-            end
-            if anchors.include?(node)
-              anchor_indexes << index
-              last_anchor = index
-            end
-          end
-          matched
+      nodeset.group_by(&:parent).flat_map do |parent, sibling_nodes|
+        anchors = Set.new.compare_by_identity.replace(sibling_nodes)
+        children = parent.children
+        children = children.reverse if reverse
+        followings = children.drop_while {|child| !anchors.include?(child) }.drop(1)
+        events = [:push]
+        followings.each do |node|
+          events << node if tester.call(node)
+          events << :push if anchors.include?(node)
         end
-      else # Slow path for :nodesets, :reverse_index_eq, :reverse_index_lt, :reverse_index_gt
-        nodesets = nodeset.map do |node|
-          parent = node.parent
-          index = parent.children.index(node)
-          reverse ? parent.children[0...index].reverse : parent.children[index + 1..-1]
-        end
-        non_optimized_nodesets_select(nodesets, tester, selector)
+        anchors.size.times { events << :pop }
+        sequence_positional_scan(events, selector)
       end
     end
 
@@ -829,48 +790,142 @@ module REXML
     # Scanner for descendant axis
     def descendant(nodeset, tester, selector, include_self: false)
       nodeset = nodeset.select {|node| node.respond_to?(:children) }
-      case selector
-      when :uniq
-        seen = Set.new.compare_by_identity
-        recursive = ->(node) do
-          node_type = node.node_type
-          return if seen.include?(node)
-          seen << node if node_type != :xmldecl
-          return unless node_type == :element || node_type == :document
-          node.children.each do |child|
-            recursive.call(child)
-          end
-        end
-        nodeset.each do |node|
-          if include_self
-            recursive.call(node)
-          else
-            node.children.each(&recursive)
-          end
-        end
-        seen.select(&tester)
-      else
-        nodesets = nodeset.map do |node|
-          new_nodeset = []
-          new_nodes = {}
-          descendant_recursive(node, new_nodeset, new_nodes, include_self)
-          new_nodeset
-        end
-        non_optimized_nodesets_select(nodesets, tester, selector)
+      targets = Set.new.compare_by_identity.replace(nodeset)
+      descendant_anchor_roots(nodeset).flat_map do |root|
+        descendant_positional_scan(root, targets, tester, selector, include_self)
       end
     end
 
-    def descendant_recursive(node, new_nodeset, new_nodes, include_self)
-      if include_self
-        return if new_nodes.key?(node)
-        new_nodeset << node
-        new_nodes[node] = true
+    def descendant_anchor_roots(nodes)
+      seen = Set.new.compare_by_identity
+      nodes.each do |node|
+        descendant_traverse(node, include_self: false) do |n|
+          if !seen.include?(n)
+            seen << n
+            true
+          end
+        end
+      end
+      nodes.reject {|node| seen.include?(node) }
+    end
+
+    def descendant_positional_scan(root, targets, tester, selector, include_self)
+      events = []
+      descendant_traverse_event(root) do |type, node|
+        if type == :enter
+          if include_self
+            events << :push if targets.include?(node)
+            events << node if tester.call(node)
+          else
+            events << node if !node.equal?(root) && tester.call(node)
+            events << :push if targets.include?(node)
+          end
+        elsif type == :leave
+          events << :pop if targets.include?(node)
+        end
+      end
+      sequence_positional_scan(events, selector)
+    end
+
+    # Select nodes matching the positional predicate from a sequence of events.
+    # Events are: :push, :pop, and node
+    # push/pop is an event that pushes/pops an anchor of position-based predicate
+    def sequence_positional_scan(events, selector)
+      case selector
+      when :uniq
+        return events.grep_v(Symbol)
+      when :nodesets
+        nodes = []
+        indexes = []
+        nodesets = []
+        last_range = nil
+        events.each do |e|
+          case e
+          when :push
+            indexes << nodes.size
+          when :pop
+            start_idx = indexes.pop
+            range = start_idx...nodes.size
+            nodesets << nodes[range] if last_range != range
+            last_range = range
+          else
+            nodes << e
+          end
+        end
+        return nodesets
       end
 
-      node_type = node.node_type
-      if node_type == :element or node_type == :document
-        node.children.each do |child|
-          descendant_recursive(child, new_nodeset, new_nodes, true)
+      operator, value = selector
+      reverse = operator == :reverse_index_eq || operator == :reverse_index_lt || operator == :reverse_index_gt
+      events = events.reverse_each if reverse
+      start_event = reverse ? :pop : :push
+      end_event = reverse ? :push : :pop
+      anchor_indexes = []
+      anchor_set = Set.new
+      node_index = 0
+      result = []
+      events.each do |event|
+        if event == start_event
+          anchor_indexes << node_index
+          anchor_set << node_index
+        elsif event == end_event
+          idx = anchor_indexes.pop
+          anchor_set.delete(idx) if anchor_indexes.last != idx
+        else # event is a node that passed the tester
+          case operator
+          when :index_eq, :reverse_index_eq
+            result << event if anchor_set.include?(node_index - value)
+          when :index_lt, :reverse_index_lt
+            result << event if node_index - anchor_indexes.last < value
+          when :index_gt, :reverse_index_gt
+            result << event if node_index > value
+          end
+          node_index += 1
+        end
+      end
+      result
+    end
+
+    # Scans the node and its descendants in document order
+    # and dispatches two types of events: :enter and :leave for each node.
+    def descendant_traverse_event(node)
+      stack = [node]
+      until stack.empty?
+        if stack.last
+          node = stack.last
+          # Push nil as a mark that we are entering this node.
+          # If we see this mark again, we know to pop the node and yield :leave
+          stack << nil
+          yield :enter, node
+          node_type = node.node_type
+          if node_type == :element or node_type == :document
+            node.children.reverse_each do |child|
+              stack << child if child.node_type != :xmldecl
+            end
+          end
+        else
+          stack.pop
+          node = stack.pop
+          yield :leave, node
+        end
+      end
+    end
+
+    # Scans the descendants of a node in document order and yields each node to the block.
+    # If a block returns falsy value, the node's descendants are not traversed.
+    def descendant_traverse(anchor_node, include_self:)
+      stack = [anchor_node]
+      until stack.empty?
+        node = stack.pop
+        if include_self || !node.equal?(anchor_node)
+          next unless yield node
+        end
+
+        node_type = node.node_type
+        if node_type == :element or node_type == :document
+          node.children.reverse_each do |child|
+            stack << child if child.node_type != :xmldecl
+          end
         end
       end
     end
@@ -923,36 +978,14 @@ module REXML
 
     # Scanner for following axis
     def following(nodeset, tester, selector)
-      nodesets = nodeset.select {|node| node.respond_to?(:parent) }.map do |node|
-        following_nodes(node)
+      anchors = Set.new.compare_by_identity.replace(nodeset)
+      events = []
+      descendant_traverse_event(nodeset.first.document || nodeset.first.root) do |type, node|
+        events << :push if type == :leave && anchors.include?(node)
+        events << node if !events.empty? && type == :enter && tester.call(node)
       end
-      non_optimized_nodesets_select(nodesets, tester, selector)
-    end
-
-    def following_nodes(node)
-      followings = []
-      following_node = next_sibling_node(node)
-      while following_node
-        followings << following_node
-        following_node = following_node_of(following_node)
-      end
-      followings
-    end
-
-    def following_node_of( node )
-      return node.children[0] if node.kind_of?(Element) and node.children.size > 0
-
-      next_sibling_node(node)
-    end
-
-    def next_sibling_node(node)
-      psn = node.next_sibling_node
-      while psn.nil?
-        return nil if node.parent.nil? or node.parent.class == Document
-        node = node.parent
-        psn = node.next_sibling_node
-      end
-      psn
+      anchors.size.times { events << :pop }
+      sequence_positional_scan(events, selector)
     end
 
     def child(nodeset)

--- a/test/xpath/test_axis_preceding_sibling.rb
+++ b/test/xpath/test_axis_preceding_sibling.rb
@@ -98,6 +98,9 @@ module REXMLTests
         </a>
       XML
 
+      assert_equal(%w[1 3 4 5 7 9 11], XPath.match(doc, "/a/anchor/preceding-sibling::b[@id][position() mod 4 = 1]").map {|n| n.attributes["id"] })
+      assert_equal(%w[5 9 10 12], XPath.match(doc, "/a/anchor/following-sibling::b[@id][position() mod 4 = 1]").map {|n| n.attributes["id"] })
+
       assert_equal(%w[2 7 9], XPath.match(doc, "/a/anchor/preceding-sibling::b[position() = 3]").map {|n| n.attributes["id"] })
       assert_equal(%w[2 3 4 7 8 9 10 11], XPath.match(doc, "/a/anchor/preceding-sibling::b[position() <= 3]").map {|n| n.attributes["id"] })
       assert_equal(%w[2 3 4 7 8 9 10 11], XPath.match(doc, "/a/anchor/preceding-sibling::b[4 > position()]").map {|n| n.attributes["id"] })

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -93,6 +93,56 @@ module REXMLTests
       assert_equal( 1, XPath.match( doc, "/descendant::z[1]" ).size )
     end
 
+    def test_descendant_positions
+      positions = ['[1]', '[position() <= 2]', '[last()]', '[position() mod 3 = 1]']
+      anchors = {
+        '//a[@id=1]'  => [%w[2], %w[2 3], %w[18], %w[2 5 8 10 13 16]],
+        '//b[@id=2]'  => [%w[3], %w[3 4], %w[4], %w[3]],
+        '//e[@id=9]'  => [%w[10], %w[10 11], %w[14], %w[10 13]],
+        '//f[@id=12]' => [%w[13], %w[13], %w[13], %w[13]],
+      }
+      anchors.each do |anchor_xpath, expecteds|
+        positions.zip(expecteds).each do |position, expected|
+          xpath = "#{anchor_xpath}/descendant::*#{position}"
+          assert_equal(expected, XPath.match(@@doc, xpath).map {|n| n['id'] }, xpath)
+        end
+      end
+      expecteds = anchors.values.transpose.map {|ids| ids.flatten.uniq.sort_by(&:to_i) }
+      positions.zip(expecteds).each do |position, expected|
+        xpath = "(#{anchors.keys.join('|')})/descendant::*#{position}"
+        assert_equal(expected, XPath.match(@@doc, xpath).map {|n| n['id'] }, xpath)
+      end
+    end
+
+    def test_descendant_or_self_positions
+      positions = ['[1]', '[position() <= 2]', '[last()]', '[position() mod 3 = 1]']
+      anchors = {
+        '//a[@id=1]'  => [%w[1], %w[1 2], %w[18], %w[1 4 7 9 12 15 18]],
+        '//b[@id=2]'  => [%w[2], %w[2 3], %w[4], %w[2]],
+        '//e[@id=9]'  => [%w[9], %w[9 10], %w[14], %w[9 12]],
+        '//f[@id=12]' => [%w[12], %w[12 13], %w[13], %w[12]],
+      }
+      anchors.each do |anchor_xpath, expecteds|
+        positions.zip(expecteds).each do |position, expected|
+          xpath = "#{anchor_xpath}/descendant-or-self::*#{position}"
+          assert_equal(expected, XPath.match(@@doc, xpath).map {|n| n['id'] }, xpath)
+        end
+      end
+      expecteds = anchors.values.transpose.map {|ids| ids.flatten.uniq.sort_by(&:to_i) }
+      positions.zip(expecteds).each do |position, expected|
+        xpath = "(#{anchors.keys.join('|')})/descendant-or-self::*#{position}"
+        assert_equal(expected, XPath.match(@@doc, xpath).map {|n| n['id'] }, xpath)
+      end
+    end
+
+    def test_following_positions
+      anchor_xpath = '(//b[@id=2]|//e[@id=9]|//f[@id=12])'
+      assert_equal(%w[5 14 15], XPath.match(@@doc, "#{anchor_xpath}/following::*[1]").map {|n| n['id'] })
+      assert_equal(%w[5 6 14 15 16], XPath.match(@@doc, "#{anchor_xpath}/following::*[position()<=2]").map {|n| n['id'] })
+      assert_equal(%w[18], XPath.match(@@doc, "#{anchor_xpath}/following::*[last()]").map {|n| n['id'] })
+      assert_equal(%w[5 8 10 13 14 15 16 17 18], XPath.match(@@doc, "#{anchor_xpath}/following::*[position() mod 3 = 1]").map {|n| n['id'] })
+    end
+
     def test_root
       source = "<a><b/></a>"
       doc = Document.new( source )


### PR DESCRIPTION
GitHub: Fix GH-331

Unify the positional-predicate handling of the `descendant`, `descendant-or-self`,
`following`, `following-sibling`, and `preceding-sibling` axes into a single
event-stream mechanism (`sequence_positional_scan`).

## Detail

Consider xpath like this: `anchor/axis::*[test-predicate][simple-positional-predicate]`.
Some xpath axes (descendant, descendant-or-self, following, preceding-sibling, following-sibling) have same common structure:
- Anchor start point, anchor end point, and nodes that passed test predicate lines up in a single sequence
- Anchor start and end are nested and doesn't cross over

Example of descendant:
```
anchor1-start
  node1
  node2
  anchor2-start
    node3
    node4
  anchor2-end
  node5
  anchor3-start
    node6
  anchor3-end
  node7
anchor1-end

# Nodesets: [
#   [node1, node2, node3, node4, node5, node6, node7], # from anchor1
#   [node3, node4], # from anchor2
#   [node6] # from anchor3
# ]
```

The above sequence and anchor ranges can be represented as event stream like this:
```ruby
[:push, node1, node2, :push, node3, node4, :pop, node5, :push, node6, :pop, node7, :pop]
```
Events are:
- `:push`: Add a new anchor point
- `:pop`: Remove last anchor point
- `node`: Add a node that passed test predicate

Axis scanner of `following`, `descendant`, `descendant-or-self`, `preceding-sibling` and `following-sibling` will construct an event stream and passes it to `sequence_positional_scan` which implements positional predicate optimization.
Optimization logic in `sequence_positional_scan` is basically the same as the one implemented in `preceding/following-sibling` before.

## Unchanged axes (preceding, ancestor)

`preceding` and `ancestor` axes are intentionally left on the existing path. Unlike `following` axis, anchor-exclusion semantics of `preceding` axis don't fit the nested push/pop model.

## Benchmark

XPath in this benchmark is specially crafted to precisely measure axis scan without noise.
Using `*` and `count()` will avoid `O(n^2)` sort and namespace lookup which may be fixed in a near future.

```ruby
xml = '<a>'*200+'<a/>'*200+'</a>'*200
xpaths = [
  "count(//*/descendant::*[position()<10])",
  "count(//*/preceding-sibling::*[position()<10])",
  "count(//*/following-sibling::*[position()<10])",
  "count(//*/following::*[position()<10])",
]
xpaths.each do |xpath|
  puts xpath
  doc = REXML::Document.new(xml)
  t=Time.now; p [REXML::XPath.match(doc, xpath), Time.now-t]
  doc = Nokogiri::XML.parse(xml)
  t=Time.now; p [doc.xpath(xpath), Time.now-t]
end
```

| scenario | REXML(master) | REXML(this PR) | Nokogiri |
| --- | --- | --- | --- |
| `descendant::*[position()<10]` | 0.032287 sec | 0.002089 sec | 0.010074 sec |
| `preceding-sibling::*[position()<10]` | 0.001075 sec | 0.001239 sec | 0.00265 sec |
| `following-sibling::*[position()<10]` | 0.000892 sec | 0.001041 sec | 0.002627 sec |
| `following::*[position()<10]` | 0.110464 sec | 0.000942 sec | 0.002706 sec |

In this example, XPath match is faster than Nokogiri, mainly because nokogiri doesn't optimize `[position()<N]`.
