### PR TITLE
Fix XPath variable handling and invalid value contamination

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -57,6 +57,7 @@ module REXML
     # Since REXML is non-validating, this method is not implemented as it
     # requires a DTD
     def id( object )
+      []
     end
 
     def local_name(node_set=nil)

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -72,7 +72,8 @@ module REXML
       @namespaces = namespaces
     end
 
-    def variables=( vars={} )
+    def variables=(vars)
+      vars = vars.transform_values { |v| coerce_variable(v) }
       @functions.variables = vars
       @variables = vars
     end
@@ -244,7 +245,8 @@ module REXML
           end
         when :variable
           var_name = path_stack.shift
-          value = coerce_variable(@variables[var_name])
+          value = @variables[var_name]
+          raise NameError, "Undefined variable: $#{var_name}" if value.nil?
           return value if path_stack.empty?
 
           nodeset = apply_remaining_predicates(path_stack, value)
@@ -346,18 +348,23 @@ module REXML
       end
     end
 
-    # Coerces a variable value to a type that can be used in XPath expressions.
-    # TODO: Decide whether REXML should warn, raise, or ignore when a variable value is invalid.
+    # Validates and coerces a variable value to a type that can be used in XPath expressions.
     def coerce_variable(value)
       case value
       when REXML::Node
         [value]
       when Array
-        value.grep(REXML::Node).uniq
+        unless value.all?(REXML::Node)
+          raise TypeError, 'Array variable must contain only REXML::Node objects'
+        end
+        value.uniq
       when Numeric, String, true, false
         value
-      else
+      when nil
+        # Convert to an empty string for backward compatibility
         ""
+      else
+        raise TypeError, "Unsupported variable type: #{value.class}"
       end
     end
 

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -107,7 +107,7 @@ module REXML
     end
 
     def []=( variable_name, value )
-      @variables[ variable_name ] = value
+      @variables[variable_name] = coerce_variable(value)
     end
 
 

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -347,6 +347,8 @@ module REXML
     # TODO: Decide whether REXML should warn, raise, or ignore when a variable value is invalid.
     def coerce_variable(value)
       case value
+      when REXML::Node
+        [value]
       when Array
         value.grep(REXML::Node).uniq
       when Numeric, String, true, false

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -244,8 +244,10 @@ module REXML
           end
         when :variable
           var_name = path_stack.shift
-          return @variables[var_name]
+          value = coerce_variable(@variables[var_name])
+          return value if path_stack.empty?
 
+          nodeset = apply_remaining_predicates(path_stack, value)
         when :eq, :neq, :lt, :lteq, :gt, :gteq
           left = expr( path_stack.shift, nodeset.dup, context )
           right = expr( path_stack.shift, nodeset.dup, context )
@@ -319,15 +321,9 @@ module REXML
         when :group
           sub_expression = path_stack.shift
           result = expr(sub_expression, nodeset, context)
-          if result.is_a?(Array)
-            # If result is a nodeset, apply following predicates
-            path_stack.unshift(:node)
-            nodeset = step(path_stack) do
-              [:iterate_nodesets, [XPathParser.sort(result)]]
-            end
-          else
-            return result
-          end
+          return result if path_stack.empty?
+
+          nodeset = apply_remaining_predicates(path_stack, result)
         else
           raise "[BUG] Unexpected path: <#{op.inspect}>: <#{path_stack.inspect}>"
         end
@@ -335,6 +331,29 @@ module REXML
       return nodeset
     ensure
       leave(:expr, path_stack, nodeset) if @debug
+    end
+
+    def apply_remaining_predicates(path_stack, value)
+      # If evaluated value is not a nodeset, treat it as an empty nodeset.
+      # TODO: Decide whether REXML should raise type error or keep this behavior.
+      value = [] unless value.is_a?(Array)
+      path_stack.unshift(:node)
+      step(path_stack) do
+        [:iterate_nodesets, [XPathParser.sort(value)]]
+      end
+    end
+
+    # Coerces a variable value to a type that can be used in XPath expressions.
+    # TODO: Decide whether REXML should warn, raise, or ignore when a variable value is invalid.
+    def coerce_variable(value)
+      case value
+      when Array
+        value.grep(REXML::Node).uniq
+      when Numeric, String, true, false
+        value
+      else
+        ""
+      end
     end
 
     # Determines if a predicate expression is dependent on the position of nodes.

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -338,8 +338,6 @@ module REXML
     end
 
     def apply_remaining_predicates(path_stack, value)
-      # If evaluated value is not a nodeset, treat it as an empty nodeset.
-      # TODO: Decide whether REXML should raise type error or keep this behavior.
       value = [] unless value.is_a?(Array)
       path_stack.unshift(:node)
       step(path_stack) do

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -317,7 +317,10 @@ module REXML
             expr(arg, nodeset, target_context)
           end
           @functions.context = target_context
-          return @functions.send(func_name, *args)
+          result = @functions.send(func_name, *args)
+          return result if path_stack.empty?
+
+          nodeset = apply_remaining_predicates(path_stack, result)
         when :group
           sub_expression = path_stack.shift
           result = expr(sub_expression, nodeset, context)

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -245,8 +245,7 @@ module REXML
           end
         when :variable
           var_name = path_stack.shift
-          value = @variables[var_name]
-          raise NameError, "Undefined variable: $#{var_name}" if value.nil?
+          value = @variables.key?(var_name) ? @variables[var_name] : ""
           return value if path_stack.empty?
 
           nodeset = apply_remaining_predicates(path_stack, value)

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1584,7 +1584,7 @@ EOF
     def test_variables
       doc = Document.new("<a><b><c/></b><d><e/></d></a>")
       a, b, c, d, e = XPath.match(doc, '//*')
-      assert_raise(NameError) { XPath.match(doc, '$y', nil, { 'x' => 1 }) }
+      assert_equal([''], XPath.match(doc, '$y', nil, { 'x' => 1 }))
       assert_raise(TypeError) { XPath.match(doc, '$x', nil, { 'x' => Object.new }) }
       assert_raise(TypeError) { XPath.match(doc, '/a', nil, { 'x' => Object.new }) }
       assert_raise(TypeError) { XPath.match(doc, '$x', nil, { 'x' => [a, Object.new, b] }) }

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1584,9 +1584,13 @@ EOF
     def test_variables
       doc = Document.new("<a><b><c/></b><d><e/></d></a>")
       a, b, c, d, e = XPath.match(doc, '//*')
-      assert_equal([''], XPath.match(doc, '$x', nil, {}))
+      assert_raise(NameError) { XPath.match(doc, '$y', nil, { 'x' => 1 }) }
+      assert_raise(TypeError) { XPath.match(doc, '$x', nil, { 'x' => Object.new }) }
+      assert_raise(TypeError) { XPath.match(doc, '/a', nil, { 'x' => Object.new }) }
+      assert_raise(TypeError) { XPath.match(doc, '$x', nil, { 'x' => [a, Object.new, b] }) }
+      assert_equal([1], XPath.match(doc, '$x', nil, { 'x' => 1 }))
+      assert_equal([false], XPath.match(doc, '$x', nil, { 'x' => false }))
       assert_equal([''], XPath.match(doc, '$x', nil, { 'x' => nil }))
-      assert_equal([''], XPath.match(doc, '$x', nil, { 'x' => Object.new }))
       assert_equal([3], XPath.match(doc, 'count($x)', nil, { 'x' => [b, c, d] }))
       assert_equal([3], XPath.match(doc, 'count($x)', nil, { 'x' => [a, a, b, b, c, c] }))
       assert_equal([b, c, d], XPath.match(doc, '$x', nil, { 'x' => [d, c, b] }))

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1573,5 +1573,37 @@ EOF
       assert_equal(["e"], XPath.match(doc, "//e[10 + preceding-sibling::* = 11]").map(&:name))
       assert_equal(["e"], XPath.match(doc, "//e[preceding-sibling::* = '1']").map(&:name))
     end
+
+    def test_unimplemented_id_should_not_contaminate_nil
+      doc = Document.new("<root/>")
+      assert_equal([], XPath.match(doc, 'id("foo")'))
+      assert_equal([], XPath.match(doc, 'id("foo")[1]'))
+      assert_equal([], XPath.match(doc, 'id("foo")/bar'))
+    end
+
+    def test_variables
+      doc = Document.new("<a><b><c/></b><d><e/></d></a>")
+      a, b, c, d, e = XPath.match(doc, '//*')
+      assert_equal([''], XPath.match(doc, '$x', nil, {}))
+      assert_equal([''], XPath.match(doc, '$x', nil, { 'x' => nil }))
+      assert_equal([''], XPath.match(doc, '$x', nil, { 'x' => Object.new }))
+      assert_equal([3], XPath.match(doc, 'count($x)', nil, { 'x' => [b, c, d] }))
+      assert_equal([3], XPath.match(doc, 'count($x)', nil, { 'x' => [a, a, b, b, c, c] }))
+      assert_equal([b, c, d], XPath.match(doc, '$x', nil, { 'x' => [d, c, b] }))
+      assert_equal([a], XPath.match(doc, '//*[name()=$x]', nil, { 'x' => 'a' }))
+      assert_equal([c, e], XPath.match(doc, '$x/*', nil, { 'x' => [b, d] }))
+    end
+
+    def test_variables_invalid_predicates
+      doc = Document.new("<root/>")
+      # Predicates after variable may be invalid depending on variable type.
+      # It can raise an exception such as TypeError, or treat the predicate result as an empty node set,
+      # but it should not return the variable value itself.
+      valid_result = [:exception, []]
+      actual = (XPath.match(doc, '$x[1<2]', nil, { 'x' => 42 }) rescue :exception)
+      assert_includes(valid_result, actual)
+      actual = (XPath.match(doc, '($x)[1<2]', nil, { 'x' => 42 }) rescue :exception)
+      assert_includes(valid_result, actual)
+    end
   end
 end

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1592,6 +1592,8 @@ EOF
       assert_equal([b, c, d], XPath.match(doc, '$x', nil, { 'x' => [d, c, b] }))
       assert_equal([a], XPath.match(doc, '//*[name()=$x]', nil, { 'x' => 'a' }))
       assert_equal([c, e], XPath.match(doc, '$x/*', nil, { 'x' => [b, d] }))
+      assert_equal([c], XPath.match(doc, '$x/*', nil, { 'x' => [b] }))
+      assert_equal([c], XPath.match(doc, '$x/*', nil, { 'x' => b }))
     end
 
     def test_variables_invalid_predicates

--- a/test/xpath/test_base.rb
+++ b/test/xpath/test_base.rb
@@ -1600,6 +1600,12 @@ EOF
       assert_equal([c], XPath.match(doc, '$x/*', nil, { 'x' => b }))
     end
 
+    def test_attribute_variables
+      doc = Document.new("<a a='1'><b a='1'/></a>")
+      a1, a2 = XPath.match(doc, '//attribute::*')
+      assert_equal([a1, a2], XPath.match(doc, '$x', nil, { 'x' => [a2, a1] }))
+    end
+
     def test_variables_invalid_predicates
       doc = Document.new("<root/>")
       # Predicates after variable may be invalid depending on variable type.


### PR DESCRIPTION
Fixes #15

Fix nil and other invalid value contamination. Nil can be injected through variables and through id function.
Unimplemented function `id()` is fixed to return `[]` instead of `nil`.
Applies predicates/path evaluation if it exists after variable.
Add variable validation (TypeError if invalid).

Variable existence check (NameError if undefined variable exist in xpath even if it is not referenced) is excluded from this PR, and just fallbacks to "" for now.

Minor behavior changes for an invalid XPath match:
```ruby
doc = REXML::Document.new("<root/>")
REXML::XPath.match(doc, '($x)[1<2]', {}, {'x'=>42})
#=> [42] → []
REXML::XPath.match(doc, '$x[1<2]', {}, {'x'=>42})
#=> [42] → []
```
It may raise TypeError (because `$x` wasn't evaluated to a nodeset), though, it shoudn't return `[42]`

## Note
Although nodeset as a variable has been accepted before, the code added in pull request explicitly permits it.
Nokogiri only accepts string value as a variable, so there's an option to limit the value types here.
Accepting nodeset may cause a problem if the passed nodes doesn't belong to a single document root. (or  just consider such case as unsupported)
