### PR TITLE
Fix xpath functions related to names

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -22,8 +22,10 @@ module REXML
       :variables,
       :variables=,
       :context=,
-      :get_namespace,
+      :target_named_node,
       :send,
+      :compare_language,
+      :string_value,
     ]
     class << self
       def method_added(name)

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -79,9 +79,9 @@ module REXML
       node =
         case node_set
         when nil
-          node = @context[:node]
+          @context[:node]
         when Array
-          node = XPathParser.sort(node_set).first
+          XPathParser.sort(node_set).first
         end
       node if node.respond_to?(:namespace)
     end

--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -61,41 +61,27 @@ module REXML
     end
 
     def local_name(node_set=nil)
-      get_namespace(node_set) do |node|
-        return node.local_name
-      end
-      ""
+      target_named_node(node_set)&.local_name || ""
     end
 
     def namespace_uri( node_set=nil )
-      get_namespace( node_set ) do |node|
-        return node.namespace
-      end
-      ""
+      target_named_node(node_set)&.namespace || ""
     end
 
     def name( node_set=nil )
-      get_namespace( node_set ) do |node|
-        return node.expanded_name
-      end
-      ""
+      target_named_node(node_set)&.expanded_name || ""
     end
 
     # Helper method.
-    def get_namespace( node_set = nil )
-      if node_set == nil
-        yield @context[:node] if @context[:node].respond_to?(:namespace)
-      else
-        if node_set.kind_of? Array
-          result = []
-          XPathParser.sort(node_set).each do |node|
-            result << yield(node) if node.respond_to?(:namespace)
-          end
-          result
-        elsif node_set.respond_to? :namespace
-          yield node_set
+    def target_named_node(node_set = nil)
+      node =
+        case node_set
+        when nil
+          node = @context[:node]
+        when Array
+          node = XPathParser.sort(node_set).first
         end
-      end
+      node if node.respond_to?(:namespace)
     end
 
     # A node-set is converted to a string by returning the string-value of the

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -13,6 +13,16 @@ module REXMLTests
       REXML::Functions.context = nil
     end
 
+    def test_available_functions
+      expected_functions = %w[
+        boolean ceiling concat contains count false floor id lang last local-name
+        name namespace-uri normalize-space not number position round starts-with
+        string string-length substring substring-after substring-before sum translate true
+      ]
+      methods = REXML::FunctionsClass.class_variable_get(:@@available_functions).keys.sort
+      assert_equal expected_functions, methods.map { |m| m.to_s.tr('_', '-') }.sort
+    end
+
     def test_functions
       # trivial text() test
       # confuse-a-function

--- a/test/functions/test_local_name.rb
+++ b/test/functions/test_local_name.rb
@@ -16,7 +16,7 @@ module REXMLTests
   <x:child/>
 </root>
       XML
-      node_set = document.root.children
+      node_set = document.root.elements.to_a
       assert_equal("child", REXML::Functions.local_name(node_set))
     end
 
@@ -27,12 +27,26 @@ module REXMLTests
   <x:child2/>
 </root>
       XML
-      node_set = document.root.children
+      node_set = document.root.elements.to_a
       assert_equal("child1", REXML::Functions.local_name(node_set))
     end
 
     def test_nonexistent
       assert_equal("", REXML::Functions.local_name([]))
+    end
+
+    def test_attribute
+      document = REXML::Document.new("<root xmlns:x='http://example.com/x/' x:attr='value' />")
+      node_set = [document.root.attributes.get_attribute("x:attr")]
+      assert_equal("attr", REXML::Functions.local_name(node_set))
+    end
+
+    def test_non_named
+      document = REXML::Document.new("<root>text<!-- comment --><a/></root>")
+      children = document.root.children
+      assert_equal("", REXML::Functions.local_name([children[0]]))
+      assert_equal("", REXML::Functions.local_name([children[1]]))
+      assert_equal("", REXML::Functions.local_name(children))
     end
 
     def test_context


### PR DESCRIPTION
Fix and simplify name(nodesets), local-name(nodesets) and namespace-uri(nodesets) node select logic. All functions that uses a single node should use the first document-ordered node, but these functions were wrongly skipping un-named nodes.

```ruby
xml = '<root>text<!-- comment --><node/></root>'
xpath = 'name(root/node())'

REXML::XPath.match(REXML::Document.new(xml), xpath)
#=> ["node"] (bug) → [""]
Nokogiri::XML.parse(xml).xpath(xpath)
#=> "" (expected)
```