### PR TITLE
ci: temporarilly pin the rbs version for JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 group :development do
   gem "rake"
   gem "rdoc"
+  gem 'rbs', '4.1.0.pre.2' if RUBY_ENGINE == 'jruby' # FIXME: https://github.com/ruby/rdoc/issues/1746
 end
 
 group :benchmark do


### PR DESCRIPTION
An error occurred while installing rbs (4.0.3), and Bundler cannot continue.

```
In Gemfile:
  rdoc was resolved to 8.0.0, which depends on
    rbs
Error: The process '/home/runner/.rubies/jruby-10.1.0.0/bin/bundle' failed with exit code 5
```

- https://github.com/ruby/rdoc/issues/1746