### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-jruby
-      min_version: 2.5
+      min_version: 2.6
 
   inplace:
     needs: ruby-versions-inplace
@@ -21,8 +21,6 @@ jobs:
           - macos-latest
           - windows-latest
         ruby-version: ${{ fromJson(needs.ruby-versions-inplace.outputs.versions) }}
-        exclude:
-          - {runs-on: macos-latest, ruby-version: 2.5}
         # include:
         #   - runs-on: ubuntu-latest
         #     ruby-version: truffleruby

--- a/rexml.gemspec
+++ b/rexml.gemspec
@@ -57,5 +57,5 @@ Gem::Specification.new do |spec|
   spec.rdoc_options.concat(["--main", "README.md"])
   spec.extra_rdoc_files = rdoc_files
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 end


### PR DESCRIPTION
## Why?
GitHub: Fix GH-271

Since it has become difficult to support Ruby 2.5, we are removing it from our list of supported versions.