### PR TITLE
Hide internal classes from documentation

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -7,7 +7,7 @@ module REXML
   # (2) all method calls from XML will have "-" replaced with "_".
   # Therefore, in XML, "local-name()" is identical (and actually becomes)
   # "local_name()"
-  class FunctionsClass
+  class FunctionsClass # :nodoc:
     @@available_functions = {}
 
     def initialize
@@ -434,5 +434,5 @@ module REXML
   # Using this singleton instance may cause thread-safety issues
   # especially when accessing variables, context and namespace_context.
   # Consider instantiating your own FunctionsClass object.
-  Functions = FunctionsClass.new
+  Functions = FunctionsClass.new # :nodoc:
 end

--- a/lib/rexml/output.rb
+++ b/lib/rexml/output.rb
@@ -2,7 +2,7 @@
 require_relative 'encoding'
 
 module REXML
-  class Output
+  class Output # :nodoc:
     include Encoding
 
     attr_reader :encoding

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -9,7 +9,7 @@ module REXML
     # for this class.  Believe me.  You don't want to poke around in here.
     # There is strange, dark magic at work in this code.  Beware.  Go back!  Go
     # back while you still can!
-    class XPathParser
+    class XPathParser # :nodoc:
       include XMLTokens
       LITERAL    = /^'([^']*)'|^"([^"]*)"/u
 

--- a/lib/rexml/source.rb
+++ b/lib/rexml/source.rb
@@ -8,7 +8,7 @@ require_relative 'encoding'
 
 module REXML
   if StringScanner::Version < "1.0.0"
-    module StringScannerCheckScanString
+    module StringScannerCheckScanString # :nodoc:
       refine StringScanner do
         def check(pattern)
           pattern = /#{Regexp.escape(pattern)}/ if pattern.is_a?(String)
@@ -35,7 +35,7 @@ module REXML
   end
 
   # Generates Source-s.  USE THIS CLASS.
-  class SourceFactory
+  class SourceFactory # :nodoc:
     # Generates a Source object
     # @param arg Either a String, or an IO
     # @return a Source, or nil if a bad argument was given
@@ -58,7 +58,7 @@ module REXML
 
   # A Source can be searched for patterns, and wraps buffers and other
   # objects and provides consumption of text
-  class Source
+  class Source # :nodoc: all
     include Encoding
     # The line number of the last consumed text
     attr_reader :line
@@ -217,7 +217,7 @@ module REXML
 
   # A Source that wraps an IO.  See the Source class for method
   # documentation
-  class IOSource < Source
+  class IOSource < Source # :nodoc:
     #attr_reader :block_size
 
     # block_size has been deprecated


### PR DESCRIPTION
## Why?
`REXML::FunctionsClass` (and the `REXML::Functions` singleton), `REXML::SourceFactory`, `REXML::Source`, `REXML::IOSource`, `REXML::Output` and `REXML::Parsers::XPathParser` are for internal use only, so mark them with `:nodoc:` to exclude them from the generated documentation.

### See
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aFunctions.html
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aSource.html
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aIOSource.html
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aSourceFactory.html
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aOutput.html
- https://docs.ruby-lang.org/ja/latest/class/REXML=3a=3aParsers=3a=3aXPathParser.html