### PR TITLE
Don't use Regexp match for `substring-after()` XPath function

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -205,8 +205,13 @@ module REXML
     # Kouhei fixed this too
     def substring_after( string, test )
       ruby_string = string(string)
-      return $1 if ruby_string =~ /#{test}(.*)/
-      ""
+      ruby_test = string(test)
+      ruby_index = ruby_string.index(ruby_test)
+      if ruby_index.nil?
+        ""
+      else
+        ruby_string[(ruby_index + ruby_test.length)..-1]
+      end
     end
 
     # Take equal portions of Mike Stok and Sean Russell; mix

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -126,6 +126,8 @@ module REXMLTests
     def test_substring_angrez
       testString = REXML::Functions::substring_after("helloworld","hello")
       assert_equal( 'world', testString )
+      testString = REXML::Functions::substring_after("helloworld","hel.o")
+      assert_equal( '', testString )
     end
 
     def test_translate


### PR DESCRIPTION
This is the current behavior:

~~~
$ irb
irb(main):001> require "rexml/document"
=> true
irb(main):002> xml = "<root><x>helloworld</x></root>"
=> "<root><x>helloworld</x></root>"
irb(main):003> doc = REXML::Document.new(xml)
=> <UNDEFINED> ... </>
irb(main):004> 
irb(main):005> xpath1 = "//x[substring-after(text(), 'hello')='world']"
=> "//x[substring-after(text(), 'hello')='world']"
irb(main):006> REXML::XPath.match(doc, xpath1)
=> [<x> ... </>]
irb(main):007> 
irb(main):008> xpath2 = "//x[substring-after(text(), 'hel.o')='world']"
=> "//x[substring-after(text(), 'hel.o')='world']"
irb(main):009> REXML::XPath.match(doc, xpath2)
=> [<x> ... </>]
irb(main):010> REXML::VERSION
=> "3.4.5"
~~~

However, XPath expects `string` match according to specification:

https://www.w3.org/TR/1999/REC-xpath-19991116/#function-substring-after

therefore the `match` for `xpath2` should actually return:

~~~
irb(main):008> xpath2 = "//x[substring-after(text(), 'hel.o')='world']"
=> "//x[substring-after(text(), 'hel.o')='world']"
irb(main):009> REXML::XPath.match(doc, xpath2)
=> []
~~~

Just for comparison, this is similar test case in Python:

~~~
$ python3
Python 3.15.0b4 (3.15.0~b4-1.fc45.x86_64, Jul 18 2026, 00:00:00) [GCC 16.1.1 20260703 (Red Hat 16.1.1-4)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from lxml import etree
... 
... xml = b'<root><x>helloworld</x></root>'
... doc = etree.fromstring(xml)
... 
... xpath1 = "//x[substring-after(text(), 'hello')='world']"
... result1 = doc.xpath(xpath1)
... print('Test 1 (hello):', result1)
... 
... xpath2 = "//x[substring-after(text(), 'hel.o')='world']"
... result2 = doc.xpath(xpath2)
... print('Test 2 (hel.o):', result2)
... 
Test 1 (hello): [<Element x at 0x7fcdbd972b00>]
Test 2 (hel.o): []
~~~