### PR TITLE
Fix Element#attribute when a namespace URI has multiple bindings

### DIFF
--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -1269,22 +1269,17 @@ module REXML
     #   document.root.attribute("x", "a") # => a:x='a:x'
     #
     def attribute( name, namespace=nil )
-      prefixes = namespace ? namespaces.select {|_, uri| uri == namespace}.keys : []
+      return attributes.get_attribute( name ) if namespace.nil?
 
-      # An unprefixed attribute is used for the default namespace.
-      if prefixes.empty? or prefixes.include?( 'xmlns' )
-        ret_val = attributes.get_attribute( name )
-        return ret_val unless ret_val.nil?
+      ret_val = attributes.get_attribute_ns( namespace, name )
+      return ret_val unless ret_val.nil?
+
+      # Kept for compatibility: an unprefixed attribute also matches when the
+      # requested URI is the default namespace or is not declared on this
+      # element, even though such an attribute is not in that namespace.
+      if namespace == namespaces[ 'xmlns' ] or !namespaces.has_value?( namespace )
+        attributes.get_attribute( name )
       end
-
-      # The same namespace URI may be bound to multiple prefixes.
-      prefixes.each do |prefix|
-        next if prefix == 'xmlns'
-        ret_val = attributes.get_attribute( "#{prefix}:#{name}" )
-        return ret_val unless ret_val.nil?
-      end
-
-      nil
     end
 
     # :call-seq:

--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -1269,20 +1269,22 @@ module REXML
     #   document.root.attribute("x", "a") # => a:x='a:x'
     #
     def attribute( name, namespace=nil )
-      prefix = namespaces.key(namespace) if namespace
-      prefix = nil if prefix == 'xmlns'
+      prefixes = namespace ? namespaces.select {|_, uri| uri == namespace}.keys : []
 
-      ret_val =
-        attributes.get_attribute( prefix ? "#{prefix}:#{name}" : name )
+      # An unprefixed attribute is used for the default namespace.
+      if prefixes.empty? or prefixes.include?( 'xmlns' )
+        ret_val = attributes.get_attribute( name )
+        return ret_val unless ret_val.nil?
+      end
 
-      return ret_val unless ret_val.nil?
-      return nil if prefix.nil?
+      # The same namespace URI may be bound to multiple prefixes.
+      prefixes.each do |prefix|
+        next if prefix == 'xmlns'
+        ret_val = attributes.get_attribute( "#{prefix}:#{name}" )
+        return ret_val unless ret_val.nil?
+      end
 
-      # now check that prefix'es namespace is not the same as the
-      # default namespace
-      return nil unless ( namespaces[ prefix ] == namespaces[ 'xmlns' ] )
-
-      attributes.get_attribute( name )
+      nil
     end
 
     # :call-seq:

--- a/test/test_element.rb
+++ b/test/test_element.rb
@@ -11,5 +11,20 @@ module REXMLTests
       doc = REXML::Document.new("<language name='Ruby'/>")
       assert_equal("Ruby", doc.root[:name])
     end
+
+    def test_attribute_duplicated_namespace_url
+      doc = REXML::Document.new("<root xmlns='url1' xmlns:ns1='url1' " +
+                                "xmlns:ns2='url2' xmlns:ns3='url2' " +
+                                "a='' ns1:a='' ns1:b='' ns2:c='' ns3:d=''/>")
+      root = doc.root
+      attributes = [
+        root.attribute("a", "url1"),
+        root.attribute("b", "url1"),
+        root.attribute("c", "url2"),
+        root.attribute("d", "url2"),
+      ]
+      assert_equal(["a", "ns1:b", "ns2:c", "ns3:d"],
+                   attributes.collect {|attribute| attribute&.expanded_name})
+    end
   end
 end

--- a/test/test_element.rb
+++ b/test/test_element.rb
@@ -23,8 +23,21 @@ module REXMLTests
         root.attribute("c", "url2"),
         root.attribute("d", "url2"),
       ]
-      assert_equal(["a", "ns1:b", "ns2:c", "ns3:d"],
+      assert_equal(["ns1:a", "ns1:b", "ns2:c", "ns3:d"],
                    attributes.collect {|attribute| attribute&.expanded_name})
+    end
+
+    def test_attribute_prefixed_match_independent_of_declaration_order
+      sources = [
+        "<root xmlns:ns1='url1' xmlns='url1' a='A' ns1:a='NS1A'/>",
+        "<root a='A' xmlns:ns1='url1' xmlns='url1' ns1:a='NS1A'/>",
+        "<root xmlns:ns1='url1' xmlns='url1' ns1:a='NS1A' a='A'/>",
+        "<root xmlns='url1' xmlns:ns1='url1' ns1:a='NS1A' a='A'/>",
+      ]
+      expanded_names = sources.collect do |source|
+        REXML::Document.new(source).root.attribute("a", "url1").expanded_name
+      end
+      assert_equal(["ns1:a"] * 4, expanded_names)
     end
   end
 end


### PR DESCRIPTION
Fixes #346.

## Motivation

`Element#attribute` can miss a namespaced attribute when the same namespace URI is bound to multiple prefixes. Lookups with prefixed attributes could also depend on declaration order.

`Attributes#get_attribute_ns` resolves the namespaced match consistently. This change makes `Element#attribute` use that result first.

## Changes

- Keep the direct `get_attribute` lookup when no namespace is supplied.
- When a namespace is supplied, call `get_attribute_ns(namespace, name)` first.
- If that finds nothing, preserve the unprefixed fallback when the requested URI is the default namespace or is not declared on the element.

A matching result from `get_attribute_ns` now wins when both prefixed and unprefixed attributes exist.

## Tests

- Add coverage for a namespace URI bound to multiple prefixes.
- Add coverage for all four relevant namespace and attribute declaration orders.

```text
ruby test/run.rb
```

799 tests, 0 failures.
