### PR TITLE
Document how Element#attribute matches a namespace

### DIFF
--- a/lib/rexml/element.rb
+++ b/lib/rexml/element.rb
@@ -1268,6 +1268,22 @@ module REXML
     #   document.root.attribute("x")      # => x='x'
     #   document.root.attribute("x", "a") # => a:x='a:x'
     #
+    # This method matches +namespace+ loosely.  An unprefixed attribute is
+    # taken to be in the default namespace, and a +namespace+ that no prefix
+    # is bound to falls back to the unprefixed attribute:
+    #
+    #   xml_string = "<root xmlns='ns0' a='a'/>"
+    #   document = REXML::Document.new(xml_string)
+    #   document.root.attribute("a", "ns0")    # => a='a'
+    #   document.root.attribute("a", "nosuch") # => a='a'
+    #
+    # The XML Namespaces specification says that an unprefixed attribute has
+    # no namespace, so neither of those should match.
+    # REXML::Attributes#get_attribute_ns follows the XML Namespaces
+    # specification and returns +nil+ for both; use it when you need the
+    # namespace to be matched strictly.  The looser behavior here is kept for
+    # compatibility.
+    #
     def attribute( name, namespace=nil )
       prefix = namespaces.key(namespace) if namespace
       prefix = nil if prefix == 'xmlns'
@@ -2492,6 +2508,18 @@ module REXML
     #   attrs = ele.attributes
     #   attrs.get_attribute_ns('http://foo', 'att')    # => foo:att='1'
     #   attrs.get_attribute_ns('http://foo', 'nosuch') # => nil
+    #
+    # +namespace+ is matched as the XML Namespaces specification defines it,
+    # where an unprefixed attribute has no namespace of its own and does not
+    # take the default one:
+    #
+    #   xml_string = "<root xmlns='ns0' a='a'/>"
+    #   attrs = REXML::Document.new(xml_string).root.attributes
+    #   attrs.get_attribute_ns('ns0', 'a') # => nil
+    #   attrs.get_attribute_ns('', 'a')    # => a='a'
+    #
+    # REXML::Element#attribute matches more loosely and returns the attribute
+    # for both of those.
     #
     def get_attribute_ns(namespace, name)
       each_effective_attribute.find do |attribute|


### PR DESCRIPTION
GitHub: Fix GH-151

`REXML::Element#attribute` matches its +namespace+ argument loosely: an unprefixed attribute is taken to be in the default namespace, and a namespace that no prefix is bound to falls back to the unprefixed attribute.

    <root xmlns='ns0' a='a'/>

    attribute("a", "ns0")    -> a='a'
    attribute("a", "nosuch") -> a='a'

The XML Namespaces specification says an unprefixed attribute has no namespace and does not take the default one, so neither of those should match.  The
behavior is kept for compatibility -- it is what tickets 102 and 121 asked for, and the tests for both are still in place -- but nothing said so, which has left people reading the method unsure whether what they saw was the contract or a bug.

Say it in the documentation of both methods, and point each at the other: REXML::Attributes#get_attribute_ns matches as the XML Namespaces specification says and is what to reach for when the namespace has to be matched strictly.  It has behaved that way at least as far back as GH-151, but that discussion never mentioned it.

Reported by Hiroya Fujinami. Thanks!!!