### PR TITLE
Stop fallback to XPath.match in `FunctionsClass#send`

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -428,7 +428,7 @@ module REXML
       else
         # TODO: Maybe, this is not XPath spec behavior.
         # This behavior must be reconsidered.
-        XPath.match(@context[:node], name.to_s)
+        []
       end
     end
   end

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -299,8 +299,10 @@ Coffee beans
       doc = Document.new("<root><nonexistent/></root>")
       # TODO: Maybe, this is not XPath spec behavior.
       # This behavior must be reconsidered.
-      assert_equal(doc.root.elements[1],
-                   XPath::first(doc.root, "nonexistent()"))
+      assert_nil(XPath::first(doc.root, "nonexistent()"))
+      assert_empty(XPath::match(doc.root, "nonexistent()"))
+      assert_empty(XPath::match(doc, "42()/*"))
+      assert_empty(Functions.send('42'))
     end
   end
 end


### PR DESCRIPTION
Related to #342, I found one more contamination path.

Return value of xpath function should be either number, string, boolean or nodeset. But the fallback path returns `XPath.match(unregistered_function_name)` which may return number/string/boolean wrapped in an array. (#353)
Instead of rejecting these invalid value types or unwrapping the array, simply removing the XPath-
noncompliant behavior is better.

The TODO comment below is kept because falling back to `[]` instead of raising error may be still not XPath spec behavior.
```ruby
# TODO: Maybe, this is not XPath spec behavior.
# This behavior must be reconsidered.
```

Related bugs/glitch (though it's probably a combination of bug in REXML::Parsers::XPathParser)
```ruby
REXML::XPath::match(REXML::Document.new('<root/>'), "/foo[1-2()]")
#=> []
REXML::XPath::match(REXML::Document.new('<root/>'), "/root[1-2()]")
#=> Garbage component exists at the end: <_2>: <1_2> (REXML::ParseException)

# Invalid type contamination
REXML::XPath::match(REXML::Document.new('<root/>'), "41()/a")
#=> undefined method 'node_type' for an instance of Integer (NoMethodError)

REXML::XPath::match(REXML::Document.new('<local-namae/>'), "local-namae()")
# => []
REXML::XPath::match(REXML::Document.new('<local_namae/>'), "local-namae()")
# => [<local_namae/>]
```