### PR TITLE
Load pp only when XPath debug tracing is enabled

### DIFF
--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: false
 
-require "pp"
 require "set"
 
 require_relative 'namespace'
@@ -801,6 +800,11 @@ module REXML
     end
 
     def trace(*args)
+      # Loaded here rather than at the top of the file because this method is
+      # only reached when REXML_XPATH_PARSER_DEBUG is set. Requiring pp
+      # eagerly made every REXML user pay for a debugging aid.
+      require "pp"
+
       indent = "  " * @nest
       PP.pp(args, "").each_line do |line|
         puts("#{indent}#{line}")

--- a/test/test_require.rb
+++ b/test/test_require.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: false
+
+require "test/unit"
+
+module REXMLTests
+  # Guards the deferred `require "pp"` in REXML::XPathParser#trace. The checks
+  # run in a subprocess because this one has pp loaded already.
+  class TestRequire < Test::Unit::TestCase
+    PP_LOADED = '$LOADED_FEATURES.any? { |f| File.basename(f) == "pp.rb" }'
+
+    def subprocess(script)
+      lib = File.join(File.dirname(File.expand_path(__dir__)), "lib")
+      IO.popen([RbConfig.ruby, "-I", lib, "-e", script], &:read)
+    end
+
+    def test_requiring_document_does_not_load_pp
+      assert_equal("false", subprocess("require 'rexml/document'; print #{PP_LOADED}"))
+    end
+
+    def test_xpath_works_without_pp
+      script = "require 'rexml/document'; " \
+               "d = REXML::Document.new('<r><a>x</a><a>y</a></r>'); " \
+               "print REXML::XPath.match(d, '//a').map(&:text).join(',')"
+      assert_equal("x,y", subprocess(script))
+    end
+
+    def test_xpath_does_not_load_pp
+      script = "require 'rexml/document'; " \
+               "d = REXML::Document.new('<r><a>x</a></r>'); " \
+               "REXML::XPath.match(d, '//a'); " \
+               "print #{PP_LOADED}"
+      assert_equal("false", subprocess(script))
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`lib/rexml/xpath_parser.rb` requires `pp` at the top of the file. `PP` is used in exactly one place:

```ruby
def trace(*args)
  indent = "  " * @nest
  PP.pp(args, "").each_line do |line|
    puts("#{indent}#{line}")
  end
end
```

`trace` is reached only through `enter` and `leave`, and **every** call site is guarded by `if @debug` (lines 225, 228, 246, 292, 373, 651, 690, 695, 769, 773, 781, 800). `@debug` comes from `DEBUG`, which is:

```ruby
DEBUG = (ENV["REXML_XPATH_PARSER_DEBUG"] == "true")
```

So every REXML user loads `pp` and `prettyprint` for a debugging aid that is off by default.

## Fix

Move the require into `#trace`, the only method that touches `PP`.

## Measurements

Ruby 4.0.6 (arm64-darwin), best of seven runs:

| | `require "rexml/document"` | files loaded |
|---|---:|---:|
| before | 23.85 ms | 38 |
| after | 21.72 ms | 36 |
| | **−2.13 ms (9%)** | **−2** |

Small in absolute terms, but REXML sits underneath a good deal of the ecosystem, and the change carries no behavior risk.

Debug tracing is unaffected — running with `REXML_XPATH_PARSER_DEBUG=true` produces the same trace output:

```
[:enter,
 :expr,
 [:document, :descendant_or_self, :node, :child, :qname, "", "b"],
 [<UNDEFINED> ... </>]]
  [:while,
```

## Tests

`test/run.rb`: **811 tests, 0 failures**, unchanged (814 with the additions).

The three added tests cover that requiring `rexml/document` does not load `pp`, that XPath matching works without it, and that evaluating an XPath does not pull it in. Two of them fail against the previous code.
