### PR TITLE
Cleanup unused accessor methods inf REXML::Functions

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -12,16 +12,10 @@ module REXML
 
     def initialize
       @context = nil
-      @namespace_context = {}
-      @variables = {}
       @node_indexes = nil
     end
 
     INTERNAL_METHODS = [
-      :namespace_context,
-      :namespace_context=,
-      :variables,
-      :variables=,
       :context=,
       :node_indexes=,
       :target_named_node,
@@ -36,11 +30,6 @@ module REXML
         end
       end
     end
-
-    def namespace_context=(x) ; @namespace_context=x ; end
-    def variables=(x) ; @variables=x ; end
-    def namespace_context ; @namespace_context ; end
-    def variables ; @variables ; end
 
     def context=(value); @context = value; end
 
@@ -433,8 +422,7 @@ module REXML
     end
   end
 
-  # Using this singleton instance may cause thread-safety issues
-  # especially when accessing variables, context and namespace_context.
+  # Using this singleton instance may cause thread-safety issues.
   # Consider instantiating your own FunctionsClass object.
   Functions = FunctionsClass.new # :nodoc:
 end

--- a/lib/rexml/parsers/xpathparser.rb
+++ b/lib/rexml/parsers/xpathparser.rb
@@ -14,7 +14,6 @@ module REXML
       LITERAL    = /^'([^']*)'|^"([^"]*)"/u
 
       def namespaces=( namespaces )
-        Functions::namespace_context = namespaces
         @namespaces = namespaces
       end
 

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -73,14 +73,11 @@ module REXML
     end
 
     def namespaces=( namespaces={} )
-      @functions.namespace_context = namespaces
       @namespaces = namespaces
     end
 
     def variables=(vars)
-      vars = vars.transform_values { |v| coerce_variable(v) }
-      @functions.variables = vars
-      @variables = vars
+      @variables = vars.transform_values { |v| coerce_variable(v) }
     end
 
     def parse path, node


### PR DESCRIPTION
Removes unused `Functions.variables`. It was write only, never read.
Removes `Functions.namespace_context`. It was only used from QuickPath, and QuickPath has been removed in #362