### PR TITLE
Change XPath available function check from denylist to allowlist

### DIFF
--- a/lib/rexml/functions.rb
+++ b/lib/rexml/functions.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: false
+
+require 'set'
+
 module REXML
   # If you add a method, keep in mind two things:
   # (1) the first argument will always be a list of nodes from which to
@@ -13,14 +16,35 @@ module REXML
       @node_indexes = nil
     end
 
-    INTERNAL_METHODS = [
-      :context=,
-      :node_indexes=,
-      :target_named_node,
-      :send,
-      :compare_language,
-      :string_value,
-    ].freeze
+    AVAILABLE_FUNCTIONS = %w[
+      boolean
+      ceiling
+      concat
+      contains
+      count
+      false
+      floor
+      id
+      lang
+      last
+      local-name
+      name
+      namespace-uri
+      normalize-space
+      not
+      number
+      position
+      round
+      starts-with
+      string
+      string-length
+      substring
+      substring-after
+      substring-before
+      sum
+      translate
+      true
+    ].to_set.freeze
 
     def context=(value); @context = value; end
 
@@ -402,16 +426,20 @@ module REXML
       end
     end
 
-    def send(name, *args)
-      name = name.to_sym
-      if self.class.method_defined?(name, false) and
-          !INTERNAL_METHODS.include?(name)
-        super
+    def call(name, args:, fallback: nil)
+      name = name.to_s
+      if AVAILABLE_FUNCTIONS.include?(name)
+        __send__(name.tr('-', '_'), *args)
+      elsif fallback.nil?
+        raise ArgumentError, "Unknown XPath function: #{name}"
       else
-        # TODO: Maybe, this is not XPath spec behavior.
-        # This behavior must be reconsidered.
-        []
+        fallback
       end
+    end
+
+    # For compatibility. Use `call` instead.
+    def send(name, *args)
+      call(name.to_s.tr('_', '-'), args: args, fallback: [])
     end
   end
 

--- a/lib/rexml/xpath_parser.rb
+++ b/lib/rexml/xpath_parser.rb
@@ -329,7 +329,7 @@ module REXML
           return -@functions.number(res)
         when :not
         when :function
-          func_name = path_stack.shift.tr('-','_')
+          func_name = path_stack.shift
           arguments = path_stack.shift
 
           if nodeset.size != 1
@@ -351,7 +351,11 @@ module REXML
             expr(arg, nodeset, target_context)
           end
           @functions.context = target_context
-          result = @functions.send(func_name, *args)
+
+          # TODO: Maybe, this is not XPath spec behavior.
+          # This behavior must be reconsidered.
+          result = @functions.call(func_name.tr('_', '-'), args: args, fallback: [])
+
           return result if path_stack.empty?
 
           nodeset = apply_remaining_predicates(path_stack, result)

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -21,7 +21,9 @@ module REXMLTests
       ]
       assert_equal expected_functions, REXML::FunctionsClass::AVAILABLE_FUNCTIONS.to_a.sort
       expected_functions.each do |name|
-        assert(REXML::FunctionsClass.method_defined?(name.tr('-', '_')), name)
+        assert do
+          REXML::FunctionsClass.method_defined?(name.tr('-', '_'))
+        end
       end
     end
 

--- a/test/functions/test_base.rb
+++ b/test/functions/test_base.rb
@@ -19,9 +19,10 @@ module REXMLTests
         name namespace-uri normalize-space not number position round starts-with
         string string-length substring substring-after substring-before sum translate true
       ]
-      methods = REXML::FunctionsClass.instance_methods(false) -
-        REXML::FunctionsClass::INTERNAL_METHODS
-      assert_equal expected_functions, methods.map { |m| m.to_s.tr('_', '-') }.sort
+      assert_equal expected_functions, REXML::FunctionsClass::AVAILABLE_FUNCTIONS.to_a.sort
+      expected_functions.each do |name|
+        assert(REXML::FunctionsClass.method_defined?(name.tr('-', '_')), name)
+      end
     end
 
     def test_functions
@@ -297,13 +298,21 @@ Coffee beans
     end
 
     def test_nonexistent_function
+      assert_raise(ArgumentError) { Functions.call('nonexistent', args: []) }
+      assert_raise(ArgumentError) { Functions.call('string_length', args: ['abc']) }
+      assert_empty(Functions.call('string_length', args: ['abc'], fallback: []))
+      assert_equal(false, Functions.call('nonexistent', args: [], fallback: false))
+      assert_equal(3, Functions.call(:'string-length', args: ['abc']))
+
       doc = Document.new("<root><nonexistent/></root>")
       # TODO: Maybe, this is not XPath spec behavior.
       # This behavior must be reconsidered.
       assert_nil(XPath::first(doc.root, "nonexistent()"))
       assert_empty(XPath::match(doc.root, "nonexistent()"))
       assert_empty(XPath::match(doc, "42()/*"))
-      assert_empty(Functions.send('42'))
+      assert_equal(3, Functions.send('string_length', 'abc'))
+      assert_equal(3, Functions.send(:string_length, 'abc'))
+      assert_empty(Functions.send(:nonexistent))
     end
   end
 end


### PR DESCRIPTION
Define an allowlist of available xpath functions Instead of listing up all internal methods which isn't xpath function. `REXML::FunctionsClass` now strictly checks function names: `local-name` is allowed but `local_name` is rejected.
The compatibility layer that accepts `local_name` is in the call site.

## Why allowlist?

Currently, REXML dropped/changed the way to add custom XPath functions in #329 that I opened.
I don't know if REXML officially supported this, it may be just a monkey patch, but perhaps it's an accidental breaking change.

```ruby
# Add custom_func and custom-func

# REXML 3.4.4
def (REXML::Functions).custom_func() = 42

# Master branch (after #329)
class REXML::FunctionsClass; def custom_func() = 42; end

# After this PR
$VERBOSE = nil # or remove_const
REXML::FunctionsClass::AVAILABLE_FUNCTIONS += %w[custom-func custom_func]
```
If we're going to drop it forever, I think static allowlist in this PR is the simplest way.
If REXML needs to re-support custom XPath function with the old style: `def (REXML::Functions).custom_func() = 42` , something needs to be done before releasing the next version. But I don't think it's easy to do it in a thread-safe way especially when the custom function touches `@context`.

## About fallback: nil
`def call(name, args:, fallback: nil)` can't distinguish nil fallback from unspecified fallback but it's OK.
Fallback should be either bool, number, string, or NodeSet. `nil` is not allowed as a value of an expression of XPath.
