### PR TITLE
Stop substituting entities with an empty value

### DIFF
--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -356,9 +356,10 @@ module REXML
       if doctype
         # Replace all ampersands that aren't part of an entity
         doctype.entities.each_value do |entity|
-          copy = copy.gsub( entity.value,
-            "&#{entity.name};" ) if entity.value and
-              not( entity_filter and entity_filter.include?(entity.name) )
+          # Skip an empty value because String#gsub("") matches at every position
+          next if entity.value.nil? or entity.value.empty?
+          next if entity_filter and entity_filter.include?(entity.name)
+          copy = copy.gsub( entity.value, "&#{entity.name};" )
         end
       else
         # Replace all ampersands that aren't part of an entity

--- a/test/test_attribute.rb
+++ b/test/test_attribute.rb
@@ -17,5 +17,17 @@ module REXMLTests
       assert_equal(true, REXML::Attribute.new("xmlns:name").namespace_declaration?)
       # REXML::Attribute.new("xmlns:xmlns") is not tested because it's invalid
     end
+
+    def test_to_string_entity
+      document = REXML::Document.new(<<-XML)
+<!DOCTYPE root [
+  <!ENTITY empty "">
+  <!ENTITY a "aaa">
+]>
+<root/>
+      XML
+      document.root.add_attribute("attr", "abc aaa")
+      assert_equal("<root attr='abc &a;'/>", document.root.to_s)
+    end
   end
 end

--- a/test/test_text.rb
+++ b/test/test_text.rb
@@ -51,6 +51,18 @@ module REXMLTests
                    Text.new(text, false, document.root, nil, ["b"]).to_s)
     end
 
+    def test_new_text_empty_entity
+      document = REXML::Document.new(<<-XML)
+<!DOCTYPE root [
+  <!ENTITY empty "">
+  <!ENTITY a "aaa">
+]>
+<root/>
+      XML
+      assert_equal("abc &a;",
+                   Text.new("abc aaa", false, document.root).to_s)
+    end
+
     def test_shift_operator_chain
       text = Text.new("original\r\n")
       text << "append1\r\n" << "append2\r\n"


### PR DESCRIPTION
`String#gsub("")` matches at every position, so an entity declared with an empty value was inserted between every character when a text node or an attribute value was normalized. 
That also kept the other entities from matching the text:

    "abc aaa" -> "abc &a;"  # was "&empty;a&empty;b&empty;c&empty; ..."

Substituting an empty entity is pointless -- a reference to it and its replacement text are equivalent -- so skipping it loses nothing.