### PR TITLE
Don't mutate the text node while pretty printing

### DIFF
--- a/lib/rexml/formatters/pretty.rb
+++ b/lib/rexml/formatters/pretty.rb
@@ -86,9 +86,8 @@ module REXML
       end
 
       def write_text( node, output )
-        s = node.to_s()
-        s.gsub!(/\s/,' ')
-        s.squeeze!(" ")
+        # Not gsub!/squeeze!: Text#to_s returns the node's own string.
+        s = node.to_s().gsub(/\s/, ' ').squeeze(" ")
         s = wrap(s, @width - @level)
         s = indent_text(s, @level, " ", true)
         output << (' '*@level + s)

--- a/test/formatter/test_pretty.rb
+++ b/test/formatter/test_pretty.rb
@@ -1,0 +1,34 @@
+module REXMLTests
+  class PrettyFormatterTest < Test::Unit::TestCase
+    def format(node, indentation=2)
+      formatter = REXML::Formatters::Pretty.new(indentation)
+      output = +""
+      formatter.write(node, output)
+      output
+    end
+
+    class TextTest < self
+      def test_source_document_is_not_modified
+        document = REXML::Document.new("<a><b>hello   world</b></a>")
+        format(document)
+        assert_equal("<a><b>hello   world</b></a>", document.to_s)
+      end
+
+      def test_raw_text_value_is_not_modified
+        text = REXML::Text.new("hello   world", true, nil, true)
+        format(text)
+        assert_equal("hello   world", text.value)
+      end
+
+      def test_whitespace_is_replaced_with_space
+        document = REXML::Document.new("<a><b>x\ty</b></a>")
+        assert_equal("<a>\n  <b>\n    x y\n  </b>\n</a>", format(document))
+      end
+
+      def test_consecutive_spaces_are_squeezed
+        document = REXML::Document.new("<a><b>x   y</b></a>")
+        assert_equal("<a>\n  <b>\n    x y\n  </b>\n</a>", format(document))
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Pretty#write_text` (`lib/rexml/formatters/pretty.rb:88-91`) calls the destructive `gsub!` and `squeeze!` on what `Text#to_s` hands back, and `Text#to_s` returns the node's own string — `@string` when `@raw`, otherwise the memoized `@normalized`:

```ruby
def to_s
  return @string if @raw
  @normalized ||= Text::normalize( @string, doctype, @entity_filter )
end
```

So pretty printing permanently rewrites the document it is printing. Through `Document#write`, the documented pretty-print entry point:

```ruby
d = REXML::Document.new("<a><b>hello   world</b></a>")
d.write(out, 2)
d.to_s
# before: "<a><b>hello world</b></a>"    <- the source had three spaces
# after:  "<a><b>hello   world</b></a>"
```

It is not only spaces. Measured the same way:

| source | `to_s` after `write(out, 2)` on master |
|---|---|
| `<a><b>hello   world</b></a>` | `<a><b>hello world</b></a>` |
| `<a><b>x &amp;   y</b></a>` | `<a><b>x &amp; y</b></a>` |
| `<a><b>line1\nline2</b></a>` | `<a><b>line1 line2</b></a>` |

With a `@raw` text node, `Text#value` itself changes.

### The other four call sites

`grep -n "node\.to_s" lib/rexml/formatters/*.rb` gives five results. Four of them — `transitive.rb:54`, `default.rb:94`, `default.rb:99`, `default.rb:105` — are `output << node.to_s`, treating the return value as read-only. `pretty.rb` was the only one writing to it.

The change is to use the non-destructive `gsub` and `squeeze`. The rendered output is byte-for-byte the same.

### Testing

New `test/formatter/test_pretty.rb`, following the `test/formatter/test_default.rb` convention, with four tests: two asserting the source is not modified, and two asserting the whitespace handling that `gsub`/`squeeze` perform.

- The two non-mutation tests fail on `master` (`<"hello   world"> expected but was <"hello world">`) and pass here.
- Mutation-checked in three directions, each failing a disjoint test: reverting to `gsub!`/`squeeze!` fails the two non-mutation tests; dropping `.squeeze` fails only `test_consecutive_spaces_are_squeezed`; dropping `.gsub` fails only `test_whitespace_is_replaced_with_space`.

Worth stating plainly: **with `test/formatter/test_pretty.rb` removed, the pre-existing 820-test suite passes under all three of those variants** — including the bug itself. There was no coverage of pretty-print whitespace handling at all, which is why the two output assertions are in the patch; without them a behaviour-preserving change here is unobservable.

- `ruby test/run.rb` (what `rake test` shells out to): `824 tests, 2634 assertions, 0 failures, 0 errors`.
- `RUBYOPT="--enable-frozen-string-literal" ruby test/run.rb`, matching the second CI job: same result. This one matters here, since the patch stops writing into a string that may be frozen.

I did not run the `rake warning:error rdoc` job — `rdoc` and `bundle` are not available in my environment. The patch adds no method and no doc comment, so I do not expect it to affect that job, but I have not executed it. I also only ran Ruby 3.2.3 on Linux, not the full 2.6+/JRuby/macOS/Windows matrix.

### Noticed but not touched

`Namespace::NAMESPLIT` uses `^` rather than `\A` and has no trailing anchor, so `"a:b:c"` splits to prefix `a`, name `b`; `Default#write_element_attributes` sorts by name while `Pretty` and `Transitive` do not. Neither is verified and neither is in this patch — mentioning them only in case they are of interest.

---

AI assistance disclosure: this patch was found and written with Claude Code. Every value above is verbatim from running it against `master` and against this branch.
