### PR TITLE
Reject invalid character references in entity expansion

### DIFF
--- a/lib/rexml/parsers/baseparser.rb
+++ b/lib/rexml/parsers/baseparser.rb
@@ -3,6 +3,7 @@ require_relative '../parseexception'
 require_relative '../undefinednamespaceexception'
 require_relative '../security'
 require_relative '../source'
+require_relative '../text'
 require 'set'
 require "strscan"
 
@@ -584,7 +585,7 @@ module REXML
           else
             code_point = Integer(m, 10)
           end
-          [code_point].pack('U*')
+          Text.expand_character_reference(code_point, "&##{m};")
         }
         matches.collect!{|x|x[0]}.compact!
         if filter

--- a/lib/rexml/text.rb
+++ b/lib/rexml/text.rb
@@ -387,12 +387,26 @@ module REXML
       }
     end
 
+    # Expands a numeric character reference's code point to a String.
+    # Code points that are not valid XML characters are rejected, matching
+    # the validation Text.check applies to literal references. This keeps the
+    # entity-expansion path from emitting XML-forbidden characters (NUL,
+    # control chars, U+FFFE/U+FFFF, code points beyond U+10FFFF, ...).
+    def Text.expand_character_reference(code_point, reference)
+      case code_point
+      when *VALID_CHAR
+        [code_point].pack('U*')
+      else
+        raise ParseException.new("Illegal character reference: <#{reference}>")
+      end
+    end
+
     def Text.expand(ref, doctype, filter, expanding: nil)
       if ref[1] == ?#
         if ref[2] == ?x
-          [ref[3...-1].to_i(16)].pack('U*')
+          expand_character_reference(ref[3...-1].to_i(16), ref)
         else
-          [ref[2...-1].to_i].pack('U*')
+          expand_character_reference(ref[2...-1].to_i, ref)
         end
       elsif ref == '&amp;'
         '&'

--- a/test/test_text.rb
+++ b/test/test_text.rb
@@ -105,5 +105,96 @@ module REXMLTests
         end
       end
     end
+
+    def test_expand_character_reference_decimal
+      assert_equal("A", Text.expand("&#65;", nil, nil))
+    end
+
+    def test_expand_character_reference_hexadecimal
+      assert_equal("A", Text.expand("&#x41;", nil, nil))
+    end
+
+    def test_expand_character_reference_supplementary_plane
+      assert_equal("\u{1F600}", Text.expand("&#x1F600;", nil, nil))
+    end
+
+    def test_expand_character_reference_forbidden_null
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#0;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#0;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_start_of_heading
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#1;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#1;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_backspace
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#8;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#8;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_vertical_tab_decimal
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#11;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#11;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_vertical_tab_hexadecimal
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#xB;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#xB;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_noncharacter_fffe
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#xFFFE;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#xFFFE;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_noncharacter_ffff
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#xFFFF;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#xFFFF;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_beyond_unicode
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#x110000;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#x110000;>", exception.to_s)
+    end
+
+    def test_expand_character_reference_forbidden_out_of_range
+      exception = assert_raise(REXML::ParseException) do
+        Text.expand("&#x80000000;", nil, nil)
+      end
+      assert_equal("Illegal character reference: <&#x80000000;>", exception.to_s)
+    end
+
+    def test_unnormalize_forbidden_character_reference
+      exception = assert_raise(REXML::ParseException) do
+        Text.unnormalize("safe text &#0; more")
+      end
+      assert_equal("Illegal character reference: <&#0;>", exception.to_s)
+    end
+
+    def test_entity_value_forbidden_character_reference
+      document = REXML::Document.new(
+        "<!DOCTYPE a [<!ENTITY e '&#0;'>]><a>&e;</a>")
+      exception = assert_raise(REXML::ParseException) do
+        document.root.children.first.value
+      end
+      assert_equal("Illegal character reference: <&#0;>", exception.to_s)
+    end
   end
 end


### PR DESCRIPTION
Text.expand and BaseParser#unnormalize packed numeric character references directly with Array#pack without validating the code point. Unlike literal references, which Text.check validates, the entity-expansion path (Text#value, attribute values, and entity values) could therefore:

  * emit XML-forbidden characters such as NUL, other control characters, and the noncharacters U+FFFE / U+FFFF, and
  * emit invalid UTF-8, or leak a bare RangeError from Array#pack, for code points beyond U+10FFFF.

These happen lazily at value-access time, so the document parses and only fails (or silently corrupts) later.

Validate the code point via the new Text.expand_character_reference against VALID_CHAR and raise REXML::ParseException for invalid values, so the expansion path behaves consistently with the literal path. The error message echoes the original reference verbatim to keep decimal and hexadecimal forms distinguishable.